### PR TITLE
fix: correct broken markdown links in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -94,8 +94,8 @@
 
 | Runbook | Description |
 |---------|-------------|
-| [Deployment](runbooks/deployment.md) | Deployment procedures |
-| [Disaster Recovery](runbooks/disaster-recovery.md) | Disaster recovery procedures |
+| [Deployment](docs/runbooks/deployment.md) | Deployment procedures |
+| [Disaster Recovery](docs/runbooks/disaster-recovery.md) | Disaster recovery procedures |
 
 ---
 

--- a/docs/getting-started/GETTING_STARTED.md
+++ b/docs/getting-started/GETTING_STARTED.md
@@ -262,11 +262,11 @@ If something goes wrong:
 
 ## Resources
 
-- **Main README**: [README.md](README.md)
-- **Deployment Guide**: [docs/runbooks/deployment.md](docs/runbooks/deployment.md)
-- **Disaster Recovery**: [docs/runbooks/disaster-recovery.md](docs/runbooks/disaster-recovery.md)
-- **Contributing**: [CONTRIBUTING.md](CONTRIBUTING.md)
-- **Changelog**: [CHANGELOG.md](CHANGELOG.md)
+- **Main README**: [README.md](../../README.md)
+- **Deployment Guide**: [docs/runbooks/deployment.md](../runbooks/deployment.md)
+- **Disaster Recovery**: [docs/runbooks/disaster-recovery.md](../runbooks/disaster-recovery.md)
+- **Contributing**: [CONTRIBUTING.md](../../CONTRIBUTING.md)
+- **Changelog**: [CHANGELOG.md](../CHANGELOG.md)
 
 ## Getting Help
 


### PR DESCRIPTION
## Summary
Fixes broken internal markdown links that were causing markdown-link-check workflow failures.

## Changes
- **docs/README.md**: Fixed runbook links (`runbooks/` → `docs/runbooks/`)
- **docs/getting-started/GETTING_STARTED.md**: Fixed relative links to root files:
  - `README.md`, `CONTRIBUTING.md` now use `../../` prefix
  - `CHANGELOG.md` uses `../` prefix
  - Runbook links corrected to `../runbooks/`

## Testing
- [ ] Markdown link checker should pass after merge
- [ ] All links should resolve correctly

## Related Issues
Resolves markdown-link-check workflow failures reported on 2025-12-22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)