### PR TITLE
fix: Remove dangerous extract() usage from all widgets

### DIFF
--- a/themes/thesource/includes/widgets/widget-about.php
+++ b/themes/thesource/includes/widgets/widget-about.php
@@ -8,7 +8,11 @@
 
 	/* Displays the Widget in the front-end */
     function widget( $args, $instance ){
-		extract($args);
+		// Extract removed for security - access $args array directly
+	$before_widget = isset( $args['before_widget'] ) ? $args['before_widget'] : '';
+	$after_widget = isset( $args['after_widget'] ) ? $args['after_widget'] : '';
+	$before_title = isset( $args['before_title'] ) ? $args['before_title'] : '';
+	$after_title = isset( $args['after_title'] ) ? $args['after_title'] : '';
 		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? 'About Me' : esc_html( $instance['title'] ) );
 		$imagePath = empty( $instance['imagePath'] ) ? '' : esc_url( $instance['imagePath'] );
 		$aboutText = empty( $instance['aboutText'] ) ? '' : $instance['aboutText'];

--- a/themes/thesource/includes/widgets/widget-ads.php
+++ b/themes/thesource/includes/widgets/widget-ads.php
@@ -8,7 +8,11 @@
 
   /* Displays the Widget in the front-end */
     function widget($args, $instance){
-		extract($args);
+		// Extract removed for security - access $args array directly
+	$before_widget = isset( $args['before_widget'] ) ? $args['before_widget'] : '';
+	$after_widget = isset( $args['after_widget'] ) ? $args['after_widget'] : '';
+	$before_title = isset( $args['before_title'] ) ? $args['before_title'] : '';
+	$after_title = isset( $args['after_title'] ) ? $args['after_title'] : '';
 		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? 'About Me' : esc_html( $instance['title'] ) );
 		$use_relpath = isset($instance['use_relpath']) ? $instance['use_relpath'] : false;
 		$new_window = isset($instance['new_window']) ? $instance['new_window'] : false;

--- a/themes/thesource/includes/widgets/widget-adsense.php
+++ b/themes/thesource/includes/widgets/widget-adsense.php
@@ -8,7 +8,11 @@
 
 	/* Displays the Widget in the front-end */
 	function widget( $args, $instance ){
-		extract($args);
+		// Extract removed for security - access $args array directly
+	$before_widget = isset( $args['before_widget'] ) ? $args['before_widget'] : '';
+	$after_widget = isset( $args['after_widget'] ) ? $args['after_widget'] : '';
+	$before_title = isset( $args['before_title'] ) ? $args['before_title'] : '';
+	$after_title = isset( $args['after_title'] ) ? $args['after_title'] : '';
 		$title = apply_filters( 'widget_title', empty( $instance['title'] ) ? 'Adsense' : esc_html( $instance['title'] ) );
 		$adsenseCode = empty( $instance['adsenseCode'] ) ? '' : $instance['adsenseCode'];
 

--- a/themes/thesource/includes/widgets/widget-popular.php
+++ b/themes/thesource/includes/widgets/widget-popular.php
@@ -8,7 +8,11 @@
 
   /* Displays the Widget in the front-end */
     function widget($args, $instance){
-		extract($args);
+		// Extract removed for security - access $args array directly
+	$before_widget = isset( $args['before_widget'] ) ? $args['before_widget'] : '';
+	$after_widget = isset( $args['after_widget'] ) ? $args['after_widget'] : '';
+	$before_title = isset( $args['before_title'] ) ? $args['before_title'] : '';
+	$after_title = isset( $args['after_title'] ) ? $args['after_title'] : '';
 		$title = apply_filters('widget_title', empty($instance['title']) ? 'Popular Posts' : $instance['title']);
 		$postsNum = empty($instance['postsNum']) ? '' : (int) $instance['postsNum'];
 

--- a/themes/thesource/includes/widgets/widget-random.php
+++ b/themes/thesource/includes/widgets/widget-random.php
@@ -8,7 +8,11 @@
 
   /* Displays the Widget in the front-end */
     function widget($args, $instance){
-		extract($args);
+		// Extract removed for security - access $args array directly
+	$before_widget = isset( $args['before_widget'] ) ? $args['before_widget'] : '';
+	$after_widget = isset( $args['after_widget'] ) ? $args['after_widget'] : '';
+	$before_title = isset( $args['before_title'] ) ? $args['before_title'] : '';
+	$after_title = isset( $args['after_title'] ) ? $args['after_title'] : '';
 		$title = apply_filters('widget_title', empty($instance['title']) ? 'Random Posts' : $instance['title']);
 		$postsNum = empty($instance['postsNum']) ? '' : (int) $instance['postsNum'];
 

--- a/themes/thesource/includes/widgets/widget-tabbed.php
+++ b/themes/thesource/includes/widgets/widget-tabbed.php
@@ -8,7 +8,11 @@
 
   /* Displays the Widget in the front-end */
     function widget($args, $instance){
-		extract($args);
+		// Extract removed for security - access $args array directly
+	$before_widget = isset( $args['before_widget'] ) ? $args['before_widget'] : '';
+	$after_widget = isset( $args['after_widget'] ) ? $args['after_widget'] : '';
+	$before_title = isset( $args['before_title'] ) ? $args['before_title'] : '';
+	$after_title = isset( $args['after_title'] ) ? $args['after_title'] : '';
 
 		$postsNumRecent = empty($instance['postsNumRecent']) ? '' : (int) $instance['postsNumRecent'];
 		$postsNumPopular = empty($instance['postsNumPopular']) ? '' : (int) $instance['postsNumPopular'];


### PR DESCRIPTION
## Summary
Removes all dangerous `extract()` function calls from widget code.

## Changes
- Replace `extract($args)` with explicit variable assignments
- Affects 6 widget files: tabbed, popular, random, about, adsense, ads
- Add security comments explaining the change
- Maintain backward compatibility with widget API

## Security Impact
**High** - Prevents variable hijacking and unexpected behavior from `extract()`.

## Testing
- Test all widgets render correctly
- Verify widget settings save properly
- Check widget titles and content display correctly
- Test in widget admin area

## Related Issues
Part of comprehensive security audit - Dangerous function usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)