### PR TITLE
fix: Convert HTTP URLs to HTTPS in child theme header

### DIFF
--- a/themes/thesource-child/header.php
+++ b/themes/thesource-child/header.php
@@ -212,9 +212,9 @@ image3.src = 'https://pausatf.org/wp-content/uploads/2014/06/TW.png'
 
 image4.src = 'https://pausatf.org/wp-content/uploads/2014/06/TWH.png'
 
-image5.src = 'http://www.pausatf.org/wp-content/uploads/2021/05/InstagramLogoBlue32.png'
+image5.src = 'https://pausatf.org/wp-content/uploads/2021/05/InstagramLogoBlue32.png'
 
-image6.src = 'http://www.pausatf.org/wp-content/uploads/2021/05/InstagramLogoGray32.png'
+image6.src = 'https://pausatf.org/wp-content/uploads/2021/05/InstagramLogoGray32.png'
 
 image7.src = 'https://pausatf.org/wp-content/uploads/2014/06/YT.png'
 
@@ -230,7 +230,7 @@ image8.src = 'https://pausatf.org/wp-content/uploads/2014/06/YTH.png'
 
 <!-- Instagram -->
 <div style="float:right; margin: 12px 10px 0 0;"><a href="https://www.instagram.com/usatfpacificassoc/" onMouseOver="document.mouseover3.src=image5.src" onMouseOut="document.mouseover3.src=image6.src" target="_blank">
-<img src="http://www.pausatf.org/wp-content/uploads/2021/05/InstagramLogoGray32.png" border=0 name="mouseover3"></a></div>
+<img src="https://pausatf.org/wp-content/uploads/2021/05/InstagramLogoGray32.png" border=0 name="mouseover3"></a></div>
 
 
 <!-- You Tube -->


### PR DESCRIPTION
## Summary
Fixes mixed content warnings by converting HTTP URLs to HTTPS.

## Changes
- Change `http://www.pausatf.org` to `https://pausatf.org`
- Affects Instagram logo image preloading and img tags
- Removes www subdomain for consistency

## Security Impact
**High** - Eliminates mixed content warnings and prevents MITM attack vectors.

## Testing
- Verify social media icons display correctly
- Check browser console for mixed content warnings (should be none)
- Test Instagram icon hover effects work

## Related Issues
Part of comprehensive security audit - Mixed content warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)