### PR TITLE
fix: Replace time() with static version for cache busting

### DIFF
--- a/themes/thesource-child/functions.php
+++ b/themes/thesource-child/functions.php
@@ -14,8 +14,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Enqueue scripts and styles for the theme
  */
 function thesource_child_enqueue_scripts() {
-    // Add a version number for cache busting
-    $version = '1.1.' . time();
+    // Use static version for proper browser caching
+    // Increment version when making changes to CSS/JS files
+    $version = '1.2.0';
     
     // Enqueue parent theme's style.css
     wp_enqueue_style( 'parent-style', get_template_directory_uri() . '/style.css' );


### PR DESCRIPTION
## Summary
Fixes severe performance issue caused by using `time()` for asset versioning.

## Changes
- Change from dynamic `time()` to static semantic version
- Update version to 1.2.0
- Add comments explaining proper cache busting

## Performance Impact
**Critical** - Enables proper browser caching for CSS/JS assets.

### Before (BAD):
- Every page load generated new version: `style.css?ver=1.1.1735365000`
- Browser never cached files
- Every visitor re-downloaded all assets on every page

### After (GOOD):
- Static version: `style.css?ver=1.2.0`
- Browser caches files until version changes
- Massive reduction in bandwidth and improved page load times

## Testing
- Verify CSS/JS files load correctly
- Check browser network tab shows cached resources (304 responses)
- Test that changing version number busts cache

## Related Issues
Part of comprehensive security audit - Performance optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)