### PR TITLE
fix: Correct malformed Theme URI in child theme stylesheet

### DIFF
--- a/themes/thesource-child/style.css
+++ b/themes/thesource-child/style.css
@@ -14,7 +14,7 @@ Theme Name: TheSource-child
 
 
 
-Theme URI: https: //pausatf.org
+Theme URI: https://pausatf.org
 
 
 


### PR DESCRIPTION
## Summary
Fixes invalid theme metadata in child theme stylesheet.

## Changes
- Remove space between 'https:' and '//pausatf.org'
- Corrects malformed URL in Theme URI header

## Impact
**Low** - Fixes theme metadata for proper WordPress theme recognition.

## Testing
- Verify theme appears correctly in WordPress admin
- Check Appearance > Themes shows correct theme URI

## Related Issues
Part of comprehensive code quality audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)