### PR TITLE
fix: Update to HTML5 DOCTYPE in theme headers

### DIFF
--- a/themes/thesource-child/header.php
+++ b/themes/thesource-child/header.php
@@ -6,11 +6,9 @@
 
       if ($colorScheme <> $default_colorscheme) $colorSchemePath = strtolower($colorScheme) . '/'; ?>
 
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-
-<html xmlns="https://www.w3.org/1999/xhtml" <?php language_attributes(); ?>>
-
-<head profile="https://gmpg.org/xfn/11">
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
 
 <meta http-equiv="Content-Type" content="<?php bloginfo('html_type'); ?>; charset=<?php bloginfo('charset'); ?>" />
 

--- a/themes/thesource/header.php
+++ b/themes/thesource/header.php
@@ -2,9 +2,9 @@
 <?php $colorSchemePath = '';
 	  $colorScheme = get_option($shortname . '_color_scheme');
       if ($colorScheme <> $default_colorscheme) $colorSchemePath = strtolower($colorScheme) . '/'; ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" <?php language_attributes(); ?>>
-<head profile="http://gmpg.org/xfn/11">
+<!DOCTYPE html>
+<html <?php language_attributes(); ?>>
+<head>
 <meta http-equiv="Content-Type" content="<?php bloginfo('html_type'); ?>; charset=<?php bloginfo('charset'); ?>" />
 <?php elegant_description(); ?>
 <?php elegant_keywords(); ?>


### PR DESCRIPTION
## Summary
Modernizes theme to use HTML5 instead of deprecated XHTML 1.0.

## Changes
- Replace XHTML 1.0 Transitional DOCTYPE with HTML5
- Remove xmlns and profile attributes (not needed in HTML5)
- Affects both parent theme and child theme headers

## Impact
**Medium** - Adopts modern HTML5 standards and best practices.

## Testing
- Verify pages render correctly
- Run HTML validator to confirm valid HTML5
- Test in multiple browsers
- Check responsive design still works

## Related Issues
Part of comprehensive code quality audit

🤖 Generated with [Claude Code](https://claude.com/claude-code)