### PR TITLE
fix(security): restrict SSH access and update EOL Ubuntu image

### DIFF
--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -31,7 +31,7 @@ variable "droplet_size" {
 variable "droplet_image" {
   description = "Droplet image/snapshot"
   type        = string
-  default     = "ubuntu-20-04-x64"
+  default     = "ubuntu-24-04-x64"
 }
 
 variable "database_size" {
@@ -55,7 +55,6 @@ variable "ssh_key_fingerprints" {
 variable "ssh_allowed_ips" {
   description = "IPs allowed to SSH (CIDR notation)"
   type        = list(string)
-  default     = ["0.0.0.0/0"] # CHANGE THIS in production!
 }
 
 variable "environment" {

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -119,11 +119,11 @@ resource "digitalocean_firewall" "staging" {
     source_addresses = ["0.0.0.0/0", "::/0"]
   }
 
-  # SSH (more permissive for staging)
+  # SSH (restricted)
   inbound_rule {
     protocol         = "tcp"
     port_range       = "22"
-    source_addresses = ["0.0.0.0/0", "::/0"]
+    source_addresses = var.ssh_allowed_ips
   }
 
   # OpenLiteSpeed WebAdmin

--- a/terraform/environments/staging/variables.tf
+++ b/terraform/environments/staging/variables.tf
@@ -31,7 +31,12 @@ variable "droplet_size" {
 variable "droplet_image" {
   description = "Droplet image/snapshot"
   type        = string
-  default     = "ubuntu-20-04-x64"
+  default     = "ubuntu-24-04-x64"
+}
+
+variable "ssh_allowed_ips" {
+  description = "IPs allowed to SSH (CIDR notation)"
+  type        = list(string)
 }
 
 variable "database_size" {


### PR DESCRIPTION
## Summary
Security hardening improvements to Terraform infrastructure:

- Replace hardcoded `0.0.0.0/0` SSH access with `var.ssh_allowed_ips` variable reference in staging
- Remove insecure default value from production `ssh_allowed_ips` variable (now required)
- Add `ssh_allowed_ips` variable to staging environment (required, no default)
- Update Ubuntu 20.04 to 24.04 in both staging and production environments (EOL mitigation)

This PR replaces #10 with a cleaner implementation.

## Test plan
- [ ] Review variable changes in both environments
- [ ] Verify no hardcoded `0.0.0.0/0` in SSH rules
- [ ] Confirm Ubuntu 24.04 image references
- [ ] Test terraform plan/apply with proper ssh_allowed_ips values

🤖 Generated with [Claude Code](https://claude.com/claude-code)