### PR TITLE
feat(teeters): scaffold pausatf-membership WordPress plugin

### DIFF
--- a/wp-content/plugins/pausatf-membership/includes/class-cpt-club.php
+++ b/wp-content/plugins/pausatf-membership/includes/class-cpt-club.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Custom post type: pausatf_club
+ *
+ * Public club directory. Replaces the legacy clubs.php / clubprofiles.php
+ * scripts that queried the pausatf_clubs MySQL database.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class PAUSATF_CPT_Club {
+
+	public static function register(): void {
+		$labels = array(
+			'name'                  => _x( 'Clubs', 'post type general name', 'pausatf-membership' ),
+			'singular_name'         => _x( 'Club', 'post type singular name', 'pausatf-membership' ),
+			'add_new_item'          => __( 'Add New Club', 'pausatf-membership' ),
+			'edit_item'             => __( 'Edit Club', 'pausatf-membership' ),
+			'view_item'             => __( 'View Club', 'pausatf-membership' ),
+			'view_items'            => __( 'View Clubs', 'pausatf-membership' ),
+			'search_items'          => __( 'Search Clubs', 'pausatf-membership' ),
+			'not_found'             => __( 'No clubs found.', 'pausatf-membership' ),
+			'not_found_in_trash'    => __( 'No clubs found in trash.', 'pausatf-membership' ),
+			'all_items'             => __( 'All Clubs', 'pausatf-membership' ),
+			'menu_name'             => __( 'Clubs', 'pausatf-membership' ),
+			'name_admin_bar'        => __( 'Club', 'pausatf-membership' ),
+		);
+
+		register_post_type(
+			'pausatf_club',
+			array(
+				'labels'       => $labels,
+				'public'       => true,
+				'has_archive'  => true,
+				'show_in_rest' => true,
+				'menu_icon'    => 'dashicons-groups',
+				'supports'     => array( 'title', 'editor', 'thumbnail', 'custom-fields' ),
+				'rewrite'      => array( 'slug' => 'clubs' ),
+			)
+		);
+
+		self::register_meta();
+	}
+
+	private static function register_meta(): void {
+		$meta_fields = array(
+			'club_code'      => array(
+				'description' => 'Short club code (e.g. LMTC)',
+				'type'        => 'string',
+			),
+			'club_city'      => array(
+				'description' => 'City where the club is based',
+				'type'        => 'string',
+			),
+			'club_state'     => array(
+				'description' => 'Two-letter state abbreviation',
+				'type'        => 'string',
+			),
+			'affiliate_type' => array(
+				'description' => 'USATF affiliate type (e.g. Club, School, Masters)',
+				'type'        => 'string',
+			),
+		);
+
+		foreach ( $meta_fields as $key => $args ) {
+			register_post_meta(
+				'pausatf_club',
+				$key,
+				array(
+					'type'              => $args['type'],
+					'description'       => $args['description'],
+					'single'            => true,
+					'show_in_rest'      => true,
+					'sanitize_callback' => 'sanitize_text_field',
+					'auth_callback'     => function (): bool {
+						return current_user_can( 'edit_posts' );
+					},
+				)
+			);
+		}
+
+		// Optional: URL to the club's Athletic.net / MileSplit results page.
+		// Not exposed in REST — editors set it via the custom fields meta box.
+		register_post_meta(
+			'pausatf_club',
+			'_club_results_url',
+			array(
+				'type'              => 'string',
+				'description'       => 'External results URL (Athletic.net, MileSplit, etc.)',
+				'single'            => true,
+				'show_in_rest'      => false,
+				'sanitize_callback' => 'esc_url_raw',
+				'auth_callback'     => function (): bool {
+					return current_user_can( 'edit_posts' );
+				},
+			)
+		);
+	}
+}

--- a/wp-content/plugins/pausatf-membership/includes/class-cpt-member.php
+++ b/wp-content/plugins/pausatf-membership/includes/class-cpt-member.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Custom post type: pausatf_member
+ *
+ * Private member roster. Not publicly queryable — members contain PII
+ * (name, club, expiry date, USATF ID). Access is gated at the shortcode
+ * and template level via current_user_can('read').
+ *
+ * Replaces the legacy members.php / fetch-members.php scripts.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class PAUSATF_CPT_Member {
+
+	public static function register(): void {
+		$labels = array(
+			'name'               => _x( 'Members', 'post type general name', 'pausatf-membership' ),
+			'singular_name'      => _x( 'Member', 'post type singular name', 'pausatf-membership' ),
+			'add_new_item'       => __( 'Add New Member', 'pausatf-membership' ),
+			'edit_item'          => __( 'Edit Member', 'pausatf-membership' ),
+			'search_items'       => __( 'Search Members', 'pausatf-membership' ),
+			'not_found'          => __( 'No members found.', 'pausatf-membership' ),
+			'not_found_in_trash' => __( 'No members found in trash.', 'pausatf-membership' ),
+			'all_items'          => __( 'All Members', 'pausatf-membership' ),
+			'menu_name'          => __( 'Members', 'pausatf-membership' ),
+			'name_admin_bar'     => __( 'Member', 'pausatf-membership' ),
+		);
+
+		register_post_type(
+			'pausatf_member',
+			array(
+				'labels'              => $labels,
+				// Private: PII — do not expose publicly.
+				'public'              => false,
+				'publicly_queryable'  => false,
+				'show_in_nav_menus'   => false,
+				'show_in_rest'        => false,
+				'show_ui'             => true,       // visible in wp-admin
+				'show_in_menu'        => true,
+				'capability_type'     => 'post',
+				'menu_icon'           => 'dashicons-id',
+				'supports'            => array( 'title', 'custom-fields' ),
+				'rewrite'             => false,
+			)
+		);
+
+		self::register_meta();
+	}
+
+	private static function register_meta(): void {
+		$meta_fields = array(
+			'member_id'         => array(
+				'description' => 'Internal member record ID from the source system',
+				'type'        => 'string',
+			),
+			'first_name'        => array(
+				'description' => 'Member first name',
+				'type'        => 'string',
+			),
+			'last_name'         => array(
+				'description' => 'Member last name',
+				'type'        => 'string',
+			),
+			'club_code'         => array(
+				'description' => 'Club code matching pausatf_club post meta',
+				'type'        => 'string',
+			),
+			'membership_type'   => array(
+				'description' => 'USATF membership category (e.g. Youth, Open, Masters)',
+				'type'        => 'string',
+			),
+			'membership_expiry' => array(
+				'description' => 'Membership expiry date — UTC ISO 8601 date string (YYYY-MM-DD)',
+				'type'        => 'string',
+			),
+			'usatf_id'          => array(
+				'description' => 'USATF member ID from Sport80',
+				'type'        => 'string',
+			),
+		);
+
+		foreach ( $meta_fields as $key => $args ) {
+			register_post_meta(
+				'pausatf_member',
+				$key,
+				array(
+					'type'              => $args['type'],
+					'description'       => $args['description'],
+					'single'            => true,
+					// Never expose member PII via REST.
+					'show_in_rest'      => false,
+					'sanitize_callback' => 'sanitize_text_field',
+					'auth_callback'     => function (): bool {
+						return current_user_can( 'edit_posts' );
+					},
+				)
+			);
+		}
+	}
+}

--- a/wp-content/plugins/pausatf-membership/includes/class-score-handler.php
+++ b/wp-content/plugins/pausatf-membership/includes/class-score-handler.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Scoresheet submission handler.
+ *
+ * Creates and manages the custom table {prefix}pausatf_scores.
+ * Replaces the legacy ScoreSheet.php which used deprecated mysql_* calls
+ * and had no CSRF protection or rate limiting.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class PAUSATF_Score_Handler {
+
+	public const NONCE_ACTION = 'pausatf_scoresheet_nonce';
+
+	// Rate limit: max submissions per IP per rolling hour.
+	private const RATE_LIMIT      = 10;
+	private const RATE_WINDOW_SEC = 3600;
+
+	public static function install_schema(): void {
+		global $wpdb;
+
+		$table   = $wpdb->prefix . 'pausatf_scores';
+		$charset = $wpdb->get_charset_collate();
+
+		$sql = "CREATE TABLE {$table} (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			meet_name varchar(255) NOT NULL,
+			meet_date date NOT NULL,
+			club_code varchar(32) NOT NULL,
+			athlete_name varchar(255) NOT NULL,
+			event_name varchar(128) NOT NULL,
+			result varchar(64) NOT NULL,
+			submitted_by varchar(255) NOT NULL,
+			submitted_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+			PRIMARY KEY (id),
+			KEY club_code (club_code),
+			KEY meet_date (meet_date)
+		) {$charset};";
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+		dbDelta( $sql );
+	}
+
+	/**
+	 * Validate, sanitize, and insert a scoresheet submission.
+	 *
+	 * @param array<string, string> $data Raw POST data.
+	 * @return int|WP_Error Inserted row ID on success, WP_Error on failure.
+	 */
+	public static function handle_submission( array $data ): int|WP_Error {
+		// Nonce verification — must be checked before any data processing.
+		$nonce = $data['_wpnonce'] ?? '';
+		if ( ! wp_verify_nonce( $nonce, self::NONCE_ACTION ) ) {
+			return new WP_Error( 'bad_nonce', __( 'Security check failed. Please refresh the page and try again.', 'pausatf-membership' ) );
+		}
+
+		// Rate limit by IP — 10 submissions per IP per hour via transient.
+		$rate_error = self::check_rate_limit();
+		if ( is_wp_error( $rate_error ) ) {
+			return $rate_error;
+		}
+
+		// Sanitize all fields.
+		$meet_name    = sanitize_text_field( $data['meet_name'] ?? '' );
+		$meet_date    = sanitize_text_field( $data['meet_date'] ?? '' );
+		$club_code    = sanitize_text_field( $data['club_code'] ?? '' );
+		$athlete_name = sanitize_text_field( $data['athlete_name'] ?? '' );
+		$event_name   = sanitize_text_field( $data['event_name'] ?? '' );
+		$result       = sanitize_text_field( $data['result'] ?? '' );
+		$submitted_by = sanitize_email( $data['submitted_by'] ?? '' );
+
+		// Validate required fields.
+		$required = compact( 'meet_name', 'meet_date', 'club_code', 'athlete_name', 'event_name', 'result', 'submitted_by' );
+		foreach ( $required as $field => $value ) {
+			if ( empty( $value ) ) {
+				return new WP_Error(
+					'missing_field',
+					sprintf( __( 'Required field "%s" is missing.', 'pausatf-membership' ), $field )
+				);
+			}
+		}
+
+		// Validate date format (YYYY-MM-DD).
+		if ( ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $meet_date ) ) {
+			return new WP_Error( 'bad_date', __( 'Meet date must be in YYYY-MM-DD format.', 'pausatf-membership' ) );
+		}
+
+		// Validate email.
+		if ( ! is_email( $submitted_by ) ) {
+			return new WP_Error( 'bad_email', __( 'Submitter email address is not valid.', 'pausatf-membership' ) );
+		}
+
+		global $wpdb;
+		$table = $wpdb->prefix . 'pausatf_scores';
+
+		$inserted = $wpdb->insert(
+			$table,
+			array(
+				'meet_name'    => $meet_name,
+				'meet_date'    => $meet_date,
+				'club_code'    => $club_code,
+				'athlete_name' => $athlete_name,
+				'event_name'   => $event_name,
+				'result'       => $result,
+				'submitted_by' => $submitted_by,
+			),
+			array( '%s', '%s', '%s', '%s', '%s', '%s', '%s' )
+		);
+
+		if ( $inserted === false ) {
+			error_log( sprintf( '[PAUSATF] score insert failed: %s', $wpdb->last_error ) );
+			return new WP_Error( 'db_error', __( 'Could not save your submission. Please try again later.', 'pausatf-membership' ) );
+		}
+
+		self::increment_rate_count();
+
+		return (int) $wpdb->insert_id;
+	}
+
+	/**
+	 * Check whether the current IP has exceeded the rate limit.
+	 *
+	 * @return true|WP_Error True if allowed, WP_Error if rate limited.
+	 */
+	private static function check_rate_limit(): true|WP_Error {
+		$key   = self::rate_transient_key();
+		$count = (int) get_transient( $key );
+
+		if ( $count >= self::RATE_LIMIT ) {
+			return new WP_Error(
+				'rate_limited',
+				__( 'Too many submissions. Please wait before submitting again.', 'pausatf-membership' )
+			);
+		}
+
+		return true;
+	}
+
+	private static function increment_rate_count(): void {
+		$key   = self::rate_transient_key();
+		$count = (int) get_transient( $key );
+
+		// set_transient with expiry only when creating; increment after.
+		if ( $count === 0 ) {
+			set_transient( $key, 1, self::RATE_WINDOW_SEC );
+		} else {
+			// Transient already set; bump the value without resetting the window.
+			// We use $wpdb directly to avoid touching the expiry.
+			global $wpdb;
+			$wpdb->query(
+				$wpdb->prepare(
+					"UPDATE {$wpdb->options} SET option_value = option_value + 1 WHERE option_name = %s",
+					'_transient_' . $key
+				)
+			);
+		}
+	}
+
+	private static function rate_transient_key(): string {
+		// Hash the IP to avoid storing it in plain text in the options table.
+		$ip = sanitize_text_field( $_SERVER['REMOTE_ADDR'] ?? '0.0.0.0' );
+		return 'pausatf_score_rate_' . md5( $ip );
+	}
+}

--- a/wp-content/plugins/pausatf-membership/includes/class-usatf-sync.php
+++ b/wp-content/plugins/pausatf-membership/includes/class-usatf-sync.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * WP-Cron daily sync for USATF membership data.
+ *
+ * Sport80 (the USATF membership platform) has no public API available to
+ * state-level associations. This sync expects a CSV file exported manually
+ * from Sport80 and placed at the path defined by PAUSATF_SYNC_CSV_PATH
+ * (set in wp-config.php or as an environment variable).
+ *
+ * CSV column expectations (header row required):
+ *   member_id, first_name, last_name, club_code, membership_type,
+ *   membership_expiry (YYYY-MM-DD), usatf_id
+ *
+ * To trigger a manual sync from WP-CLI:
+ *   wp eval 'PAUSATF_USATF_Sync::sync();'
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+class PAUSATF_USATF_Sync {
+
+	private const CRON_HOOK = 'pausatf_daily_sync';
+
+	public static function schedule(): void {
+		if ( ! wp_next_scheduled( self::CRON_HOOK ) ) {
+			// Schedule for 03:00 UTC to avoid peak traffic.
+			wp_schedule_event( strtotime( 'tomorrow 03:00 UTC' ), 'daily', self::CRON_HOOK );
+		}
+		add_action( self::CRON_HOOK, array( __CLASS__, 'sync' ) );
+	}
+
+	public static function unschedule(): void {
+		$timestamp = wp_next_scheduled( self::CRON_HOOK );
+		if ( $timestamp ) {
+			wp_unschedule_event( $timestamp, self::CRON_HOOK );
+		}
+	}
+
+	public static function sync(): void {
+		$csv_path = PAUSATF_SYNC_CSV_PATH;
+
+		if ( empty( $csv_path ) ) {
+			error_log( '[PAUSATF] sync: PAUSATF_SYNC_CSV_PATH is not set — skipping.' );
+			return;
+		}
+
+		if ( ! is_readable( $csv_path ) ) {
+			error_log( sprintf( '[PAUSATF] sync: CSV file not readable at %s — skipping.', $csv_path ) );
+			return;
+		}
+
+		$start   = microtime( true );
+		$updated = self::import_csv( $csv_path );
+		$elapsed = round( microtime( true ) - $start, 2 );
+
+		error_log( sprintf( '[PAUSATF] sync: imported %d records in %ss from %s', $updated, $elapsed, $csv_path ) );
+	}
+
+	/**
+	 * Read the CSV at $filepath, upsert pausatf_member posts, return record count.
+	 *
+	 * Upsert logic: match on member_id meta. If a post with that member_id
+	 * already exists, update its meta. Otherwise insert a new post.
+	 * The post title is set to "Last, First" for admin usability.
+	 */
+	public static function import_csv( string $filepath ): int {
+		global $wpdb;
+
+		$handle = fopen( $filepath, 'r' );
+		if ( $handle === false ) {
+			error_log( sprintf( '[PAUSATF] import_csv: fopen failed for %s', $filepath ) );
+			return 0;
+		}
+
+		// Consume header row and map column names to indices.
+		$header = fgetcsv( $handle );
+		if ( $header === false ) {
+			fclose( $handle );
+			error_log( '[PAUSATF] import_csv: empty or unreadable CSV header.' );
+			return 0;
+		}
+
+		$cols = array_flip( array_map( 'trim', $header ) );
+
+		$required = array( 'member_id', 'first_name', 'last_name', 'club_code', 'membership_type', 'membership_expiry' );
+		foreach ( $required as $col ) {
+			if ( ! isset( $cols[ $col ] ) ) {
+				fclose( $handle );
+				error_log( sprintf( '[PAUSATF] import_csv: missing required column "%s".', $col ) );
+				return 0;
+			}
+		}
+
+		$count = 0;
+
+		while ( ( $row = fgetcsv( $handle ) ) !== false ) {
+			$member_id = sanitize_text_field( trim( $row[ $cols['member_id'] ] ?? '' ) );
+			if ( empty( $member_id ) ) {
+				continue;
+			}
+
+			$first_name  = sanitize_text_field( trim( $row[ $cols['first_name'] ] ?? '' ) );
+			$last_name   = sanitize_text_field( trim( $row[ $cols['last_name'] ] ?? '' ) );
+			$club_code   = sanitize_text_field( trim( $row[ $cols['club_code'] ] ?? '' ) );
+			$mem_type    = sanitize_text_field( trim( $row[ $cols['membership_type'] ] ?? '' ) );
+			$mem_expiry  = sanitize_text_field( trim( $row[ $cols['membership_expiry'] ] ?? '' ) );
+			$usatf_id    = sanitize_text_field( trim( $row[ $cols['usatf_id'] ?? -1 ] ?? '' ) );
+
+			// Validate expiry is a plausible ISO 8601 date — reject obviously bad data.
+			if ( ! empty( $mem_expiry ) && ! preg_match( '/^\d{4}-\d{2}-\d{2}$/', $mem_expiry ) ) {
+				error_log( sprintf( '[PAUSATF] import_csv: skipping member_id %s — bad expiry format "%s".', $member_id, $mem_expiry ) );
+				continue;
+			}
+
+			// Look up existing post by member_id meta.
+			$existing_id = (int) $wpdb->get_var(
+				$wpdb->prepare(
+					"SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key = 'member_id' AND meta_value = %s LIMIT 1",
+					$member_id
+				)
+			);
+
+			$post_title = trim( $last_name . ', ' . $first_name );
+
+			if ( $existing_id > 0 ) {
+				wp_update_post( array(
+					'ID'         => $existing_id,
+					'post_title' => $post_title,
+				) );
+				$post_id = $existing_id;
+			} else {
+				$post_id = wp_insert_post( array(
+					'post_type'   => 'pausatf_member',
+					'post_title'  => $post_title,
+					'post_status' => 'publish',
+				) );
+
+				if ( is_wp_error( $post_id ) ) {
+					error_log( sprintf( '[PAUSATF] import_csv: wp_insert_post failed for member_id %s — %s', $member_id, $post_id->get_error_message() ) );
+					continue;
+				}
+			}
+
+			update_post_meta( $post_id, 'member_id',         $member_id );
+			update_post_meta( $post_id, 'first_name',        $first_name );
+			update_post_meta( $post_id, 'last_name',         $last_name );
+			update_post_meta( $post_id, 'club_code',         $club_code );
+			update_post_meta( $post_id, 'membership_type',   $mem_type );
+			update_post_meta( $post_id, 'membership_expiry', $mem_expiry );
+			update_post_meta( $post_id, 'usatf_id',          $usatf_id );
+
+			$count++;
+		}
+
+		fclose( $handle );
+		return $count;
+	}
+}
+
+add_action( 'pausatf_daily_sync', array( 'PAUSATF_USATF_Sync', 'sync' ) );

--- a/wp-content/plugins/pausatf-membership/includes/shortcodes.php
+++ b/wp-content/plugins/pausatf-membership/includes/shortcodes.php
@@ -1,0 +1,165 @@
+<?php
+/**
+ * Shortcode callbacks.
+ *
+ * [pausatf_members]    — private member roster (login required)
+ * [pausatf_clubs]      — public club directory
+ * [pausatf_scoresheet] — scoresheet submission form
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * [pausatf_members club="" per_page="25"]
+ *
+ * Requires the visitor to be logged in — member data contains PII.
+ *
+ * @param array<string, string>|string $atts
+ * @return string
+ */
+function pausatf_members_shortcode( $atts ): string {
+	if ( ! is_user_logged_in() ) {
+		return '<p class="pausatf-login-required">' .
+			wp_kses_post( sprintf(
+				/* translators: %s: login URL */
+				__( 'You must be <a href="%s">logged in</a> to view the member roster.', 'pausatf-membership' ),
+				esc_url( wp_login_url( get_permalink() ) )
+			) ) .
+			'</p>';
+	}
+
+	$atts = shortcode_atts(
+		array(
+			'club'     => '',
+			'per_page' => '25',
+		),
+		$atts,
+		'pausatf_members'
+	);
+
+	$club     = sanitize_text_field( $atts['club'] );
+	$per_page = absint( $atts['per_page'] );
+	if ( $per_page < 1 || $per_page > 200 ) {
+		$per_page = 25;
+	}
+
+	$paged = max( 1, absint( get_query_var( 'paged' ) ) );
+
+	// Override club filter from URL param if present (e.g. ?club=LMTC).
+	$url_club = sanitize_text_field( $_GET['club'] ?? '' );
+	if ( ! empty( $url_club ) ) {
+		$club = $url_club;
+	}
+
+	$query_args = array(
+		'post_type'      => 'pausatf_member',
+		'post_status'    => 'publish',
+		'posts_per_page' => $per_page,
+		'paged'          => $paged,
+		'orderby'        => 'meta_value',
+		'meta_key'       => 'last_name',
+		'order'          => 'ASC',
+	);
+
+	if ( ! empty( $club ) ) {
+		$query_args['meta_query'] = array(
+			array(
+				'key'     => 'club_code',
+				'value'   => $club,
+				'compare' => '=',
+			),
+		);
+	}
+
+	$members_query = new WP_Query( $query_args );
+
+	ob_start();
+	include PAUSATF_PLUGIN_DIR . 'templates/archive-pausatf_member.php';
+	return ob_get_clean();
+}
+
+/**
+ * [pausatf_clubs state=""]
+ *
+ * Publicly accessible club directory.
+ *
+ * @param array<string, string>|string $atts
+ * @return string
+ */
+function pausatf_clubs_shortcode( $atts ): string {
+	$atts = shortcode_atts(
+		array(
+			'state' => '',
+		),
+		$atts,
+		'pausatf_clubs'
+	);
+
+	$state = sanitize_text_field( $atts['state'] );
+
+	$query_args = array(
+		'post_type'      => 'pausatf_club',
+		'post_status'    => 'publish',
+		'posts_per_page' => -1,
+		'orderby'        => 'title',
+		'order'          => 'ASC',
+	);
+
+	if ( ! empty( $state ) ) {
+		$query_args['meta_query'] = array(
+			array(
+				'key'     => 'club_state',
+				'value'   => $state,
+				'compare' => '=',
+			),
+		);
+	}
+
+	$clubs_query = new WP_Query( $query_args );
+
+	ob_start();
+	include PAUSATF_PLUGIN_DIR . 'templates/archive-pausatf_club.php';
+	return ob_get_clean();
+}
+
+/**
+ * [pausatf_scoresheet]
+ *
+ * On POST: validate, handle submission, show confirmation or errors.
+ * On GET: render the form.
+ *
+ * @param array<string, string>|string $atts
+ * @return string
+ */
+function pausatf_scoresheet_shortcode( $atts ): string {
+	$submission_result = null;
+	$submission_errors = array();
+
+	if ( isset( $_POST['pausatf_scoresheet_submit'] ) ) {
+		$result = PAUSATF_Score_Handler::handle_submission( $_POST );
+
+		if ( is_wp_error( $result ) ) {
+			$submission_errors = $result->get_error_messages();
+		} else {
+			// Success — show confirmation and bail early.
+			return '<div class="pausatf-scoresheet-success">' .
+				esc_html__( 'Scoresheet submitted successfully. Thank you!', 'pausatf-membership' ) .
+				'</div>';
+		}
+	}
+
+	// Build club list for the dropdown.
+	$clubs_query = new WP_Query( array(
+		'post_type'      => 'pausatf_club',
+		'post_status'    => 'publish',
+		'posts_per_page' => -1,
+		'orderby'        => 'title',
+		'order'          => 'ASC',
+	) );
+
+	ob_start();
+	include PAUSATF_PLUGIN_DIR . 'templates/shortcode-scoresheet.php';
+	return ob_get_clean();
+}

--- a/wp-content/plugins/pausatf-membership/pausatf-membership.php
+++ b/wp-content/plugins/pausatf-membership/pausatf-membership.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Plugin Name:       PAUSATF Membership
+ * Description:       Club directory, member roster, and scoresheet submission for PA USATF. Replaces legacy Teeters PHP scripts (2007–2015).
+ * Version:           0.1.0
+ * Requires at least: 6.0
+ * Requires PHP:      8.0
+ * Author:            PAUSATF
+ * License:           GPL-2.0-or-later
+ * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
+ * Text Domain:       pausatf-membership
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+define( 'PAUSATF_PLUGIN_VERSION', '0.1.0' );
+define( 'PAUSATF_PLUGIN_DIR', plugin_dir_path( __FILE__ ) );
+define( 'PAUSATF_PLUGIN_URL', plugin_dir_url( __FILE__ ) );
+
+// CSV export path for Sport80 sync — override via wp-config.php or env.
+// Sport80 has no public API; the sync expects a manually placed CSV file.
+if ( ! defined( 'PAUSATF_SYNC_CSV_PATH' ) ) {
+	$_env_csv = getenv( 'PAUSATF_SYNC_CSV_PATH' );
+	define( 'PAUSATF_SYNC_CSV_PATH', $_env_csv ?: '' );
+}
+
+require_once PAUSATF_PLUGIN_DIR . 'includes/class-cpt-club.php';
+require_once PAUSATF_PLUGIN_DIR . 'includes/class-cpt-member.php';
+require_once PAUSATF_PLUGIN_DIR . 'includes/class-score-handler.php';
+require_once PAUSATF_PLUGIN_DIR . 'includes/class-usatf-sync.php';
+require_once PAUSATF_PLUGIN_DIR . 'includes/shortcodes.php';
+
+register_activation_hook( __FILE__, 'pausatf_activate' );
+register_deactivation_hook( __FILE__, 'pausatf_deactivate' );
+
+function pausatf_activate(): void {
+	PAUSATF_CPT_Club::register();
+	PAUSATF_CPT_Member::register();
+	flush_rewrite_rules();
+	PAUSATF_Score_Handler::install_schema();
+	PAUSATF_USATF_Sync::schedule();
+}
+
+function pausatf_deactivate(): void {
+	flush_rewrite_rules();
+	PAUSATF_USATF_Sync::unschedule();
+}
+
+add_action( 'init', array( 'PAUSATF_CPT_Club', 'register' ) );
+add_action( 'init', array( 'PAUSATF_CPT_Member', 'register' ) );
+
+add_action( 'wp_enqueue_scripts', 'pausatf_enqueue_scripts' );
+
+function pausatf_enqueue_scripts(): void {
+	// Only load on pages that use our shortcodes — checked via has_shortcode()
+	// on the queried post. Enqueueing here is a lightweight placeholder; a
+	// block-based approach would use block.json assets instead.
+	if ( ! is_singular() ) {
+		return;
+	}
+	$post = get_queried_object();
+	if ( ! ( $post instanceof WP_Post ) ) {
+		return;
+	}
+	$shortcodes = array( 'pausatf_members', 'pausatf_clubs', 'pausatf_scoresheet' );
+	$needed     = false;
+	foreach ( $shortcodes as $tag ) {
+		if ( has_shortcode( $post->post_content, $tag ) ) {
+			$needed = true;
+			break;
+		}
+	}
+	if ( ! $needed ) {
+		return;
+	}
+	wp_enqueue_style(
+		'pausatf-membership',
+		PAUSATF_PLUGIN_URL . 'assets/pausatf-membership.css',
+		array(),
+		PAUSATF_PLUGIN_VERSION
+	);
+}
+
+add_shortcode( 'pausatf_members',    'pausatf_members_shortcode' );
+add_shortcode( 'pausatf_clubs',      'pausatf_clubs_shortcode' );
+add_shortcode( 'pausatf_scoresheet', 'pausatf_scoresheet_shortcode' );

--- a/wp-content/plugins/pausatf-membership/templates/archive-pausatf_club.php
+++ b/wp-content/plugins/pausatf-membership/templates/archive-pausatf_club.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Club directory template.
+ *
+ * Loaded via ob_start() from pausatf_clubs_shortcode().
+ * Variables available: $clubs_query (WP_Query)
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+?>
+<div class="pausatf-clubs">
+	<?php if ( $clubs_query->have_posts() ) : ?>
+		<table class="pausatf-clubs-table">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Club', 'pausatf-membership' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'City', 'pausatf-membership' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'State', 'pausatf-membership' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Type', 'pausatf-membership' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Results', 'pausatf-membership' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php while ( $clubs_query->have_posts() ) : $clubs_query->the_post(); ?>
+					<?php
+					$post_id        = get_the_ID();
+					$city           = get_post_meta( $post_id, 'club_city', true );
+					$state          = get_post_meta( $post_id, 'club_state', true );
+					$affiliate_type = get_post_meta( $post_id, 'affiliate_type', true );
+					$results_url    = get_post_meta( $post_id, '_club_results_url', true );
+					?>
+					<tr>
+						<td>
+							<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
+						</td>
+						<td><?php echo esc_html( $city ); ?></td>
+						<td><?php echo esc_html( $state ); ?></td>
+						<td><?php echo esc_html( $affiliate_type ); ?></td>
+						<td>
+							<?php if ( ! empty( $results_url ) ) : ?>
+								<a href="<?php echo esc_url( $results_url ); ?>" target="_blank" rel="noopener noreferrer">
+									<?php esc_html_e( 'Results', 'pausatf-membership' ); ?>
+								</a>
+							<?php else : ?>
+								&mdash;
+							<?php endif; ?>
+						</td>
+					</tr>
+				<?php endwhile; ?>
+			</tbody>
+		</table>
+	<?php else : ?>
+		<p><?php esc_html_e( 'No clubs found.', 'pausatf-membership' ); ?></p>
+	<?php endif; ?>
+
+	<?php wp_reset_postdata(); ?>
+</div>

--- a/wp-content/plugins/pausatf-membership/templates/archive-pausatf_member.php
+++ b/wp-content/plugins/pausatf-membership/templates/archive-pausatf_member.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * Member roster template — NOT a public page.
+ *
+ * Loaded via ob_start() from pausatf_members_shortcode().
+ * Login check is already performed in the shortcode callback; this template
+ * is only reached when the user is authenticated.
+ *
+ * Variables available:
+ *   $members_query (WP_Query)
+ *   $club          (string) — active club filter, may be empty
+ *   $per_page      (int)
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Double-check — defence in depth. Shortcode callback already gates this.
+if ( ! current_user_can( 'read' ) ) {
+	echo '<p>' . esc_html__( 'You do not have permission to view this page.', 'pausatf-membership' ) . '</p>';
+	return;
+}
+?>
+<div class="pausatf-members">
+
+	<form class="pausatf-members-filter" method="get">
+		<label for="pausatf-club-filter"><?php esc_html_e( 'Filter by club:', 'pausatf-membership' ); ?></label>
+		<input
+			type="text"
+			id="pausatf-club-filter"
+			name="club"
+			value="<?php echo esc_attr( $club ); ?>"
+			placeholder="<?php esc_attr_e( 'Club code, e.g. LMTC', 'pausatf-membership' ); ?>"
+		>
+		<button type="submit"><?php esc_html_e( 'Filter', 'pausatf-membership' ); ?></button>
+		<?php if ( ! empty( $club ) ) : ?>
+			<a href="<?php echo esc_url( remove_query_arg( 'club' ) ); ?>"><?php esc_html_e( 'Clear', 'pausatf-membership' ); ?></a>
+		<?php endif; ?>
+	</form>
+
+	<?php if ( $members_query->have_posts() ) : ?>
+		<table class="pausatf-members-table">
+			<thead>
+				<tr>
+					<th scope="col"><?php esc_html_e( 'Last Name', 'pausatf-membership' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'First Name', 'pausatf-membership' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Club', 'pausatf-membership' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Type', 'pausatf-membership' ); ?></th>
+					<th scope="col"><?php esc_html_e( 'Expires', 'pausatf-membership' ); ?></th>
+				</tr>
+			</thead>
+			<tbody>
+				<?php while ( $members_query->have_posts() ) : $members_query->the_post(); ?>
+					<?php
+					$post_id   = get_the_ID();
+					$first     = get_post_meta( $post_id, 'first_name', true );
+					$last      = get_post_meta( $post_id, 'last_name', true );
+					$club_code = get_post_meta( $post_id, 'club_code', true );
+					$mem_type  = get_post_meta( $post_id, 'membership_type', true );
+					$expiry    = get_post_meta( $post_id, 'membership_expiry', true );
+
+					// Flag expired memberships for easy visual scanning.
+					$expired     = ! empty( $expiry ) && $expiry < gmdate( 'Y-m-d' );
+					$row_class   = $expired ? ' class="pausatf-expired"' : '';
+					?>
+					<tr<?php echo $row_class; // phpcs:ignore WordPress.Security.EscapeOutput -- only static strings ?>>
+						<td><?php echo esc_html( $last ); ?></td>
+						<td><?php echo esc_html( $first ); ?></td>
+						<td><?php echo esc_html( $club_code ); ?></td>
+						<td><?php echo esc_html( $mem_type ); ?></td>
+						<td><?php echo esc_html( $expiry ); ?></td>
+					</tr>
+				<?php endwhile; ?>
+			</tbody>
+		</table>
+
+		<div class="pausatf-pagination">
+			<?php
+			echo paginate_links( array(
+				'base'    => add_query_arg( 'paged', '%#%' ),
+				'format'  => '',
+				'current' => max( 1, absint( get_query_var( 'paged' ) ) ),
+				'total'   => $members_query->max_num_pages,
+			) );
+			?>
+		</div>
+
+	<?php else : ?>
+		<p><?php esc_html_e( 'No members found.', 'pausatf-membership' ); ?></p>
+	<?php endif; ?>
+
+	<?php wp_reset_postdata(); ?>
+</div>

--- a/wp-content/plugins/pausatf-membership/templates/shortcode-scoresheet.php
+++ b/wp-content/plugins/pausatf-membership/templates/shortcode-scoresheet.php
@@ -1,0 +1,147 @@
+<?php
+/**
+ * Scoresheet submission form template.
+ *
+ * Loaded via ob_start() from pausatf_scoresheet_shortcode().
+ *
+ * Variables available:
+ *   $clubs_query       (WP_Query)  — pausatf_club posts for the dropdown
+ *   $submission_errors (string[])  — validation errors from a failed POST
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Repopulate fields after a failed submission so the user doesn't retype everything.
+$prev = array(
+	'meet_name'    => sanitize_text_field( $_POST['meet_name'] ?? '' ),
+	'meet_date'    => sanitize_text_field( $_POST['meet_date'] ?? '' ),
+	'club_code'    => sanitize_text_field( $_POST['club_code'] ?? '' ),
+	'athlete_name' => sanitize_text_field( $_POST['athlete_name'] ?? '' ),
+	'event_name'   => sanitize_text_field( $_POST['event_name'] ?? '' ),
+	'result'       => sanitize_text_field( $_POST['result'] ?? '' ),
+	'submitted_by' => sanitize_email( $_POST['submitted_by'] ?? '' ),
+);
+?>
+<div class="pausatf-scoresheet">
+
+	<?php if ( ! empty( $submission_errors ) ) : ?>
+		<div class="pausatf-scoresheet-errors" role="alert">
+			<ul>
+				<?php foreach ( $submission_errors as $error ) : ?>
+					<li><?php echo esc_html( $error ); ?></li>
+				<?php endforeach; ?>
+			</ul>
+		</div>
+	<?php endif; ?>
+
+	<form class="pausatf-scoresheet-form" method="post">
+		<?php wp_nonce_field( PAUSATF_Score_Handler::NONCE_ACTION ); ?>
+
+		<p>
+			<label for="pausatf-meet-name"><?php esc_html_e( 'Meet Name', 'pausatf-membership' ); ?> <span aria-hidden="true">*</span></label>
+			<input
+				type="text"
+				id="pausatf-meet-name"
+				name="meet_name"
+				value="<?php echo esc_attr( $prev['meet_name'] ); ?>"
+				required
+				maxlength="255"
+			>
+		</p>
+
+		<p>
+			<label for="pausatf-meet-date"><?php esc_html_e( 'Meet Date', 'pausatf-membership' ); ?> <span aria-hidden="true">*</span></label>
+			<input
+				type="date"
+				id="pausatf-meet-date"
+				name="meet_date"
+				value="<?php echo esc_attr( $prev['meet_date'] ); ?>"
+				required
+			>
+		</p>
+
+		<p>
+			<label for="pausatf-club-code"><?php esc_html_e( 'Club', 'pausatf-membership' ); ?> <span aria-hidden="true">*</span></label>
+			<select id="pausatf-club-code" name="club_code" required>
+				<option value=""><?php esc_html_e( '— Select a club —', 'pausatf-membership' ); ?></option>
+				<?php while ( $clubs_query->have_posts() ) : $clubs_query->the_post(); ?>
+					<?php
+					$code  = get_post_meta( get_the_ID(), 'club_code', true );
+					$label = get_the_title();
+					if ( ! empty( $code ) ) {
+						$label .= ' (' . $code . ')';
+					}
+					?>
+					<option
+						value="<?php echo esc_attr( $code ); ?>"
+						<?php selected( $prev['club_code'], $code ); ?>
+					><?php echo esc_html( $label ); ?></option>
+				<?php endwhile; ?>
+				<?php wp_reset_postdata(); ?>
+			</select>
+		</p>
+
+		<p>
+			<label for="pausatf-athlete-name"><?php esc_html_e( 'Athlete Name', 'pausatf-membership' ); ?> <span aria-hidden="true">*</span></label>
+			<input
+				type="text"
+				id="pausatf-athlete-name"
+				name="athlete_name"
+				value="<?php echo esc_attr( $prev['athlete_name'] ); ?>"
+				required
+				maxlength="255"
+			>
+		</p>
+
+		<p>
+			<label for="pausatf-event-name"><?php esc_html_e( 'Event', 'pausatf-membership' ); ?> <span aria-hidden="true">*</span></label>
+			<input
+				type="text"
+				id="pausatf-event-name"
+				name="event_name"
+				value="<?php echo esc_attr( $prev['event_name'] ); ?>"
+				required
+				maxlength="128"
+				placeholder="<?php esc_attr_e( 'e.g. 100m, Shot Put', 'pausatf-membership' ); ?>"
+			>
+		</p>
+
+		<p>
+			<label for="pausatf-result"><?php esc_html_e( 'Result', 'pausatf-membership' ); ?> <span aria-hidden="true">*</span></label>
+			<input
+				type="text"
+				id="pausatf-result"
+				name="result"
+				value="<?php echo esc_attr( $prev['result'] ); ?>"
+				required
+				maxlength="64"
+				placeholder="<?php esc_attr_e( 'e.g. 11.23, 14.56m', 'pausatf-membership' ); ?>"
+			>
+		</p>
+
+		<p>
+			<label for="pausatf-submitted-by"><?php esc_html_e( 'Your Email', 'pausatf-membership' ); ?> <span aria-hidden="true">*</span></label>
+			<input
+				type="email"
+				id="pausatf-submitted-by"
+				name="submitted_by"
+				value="<?php echo esc_attr( $prev['submitted_by'] ); ?>"
+				required
+				maxlength="255"
+			>
+		</p>
+
+		<p>
+			<button type="submit" name="pausatf_scoresheet_submit" value="1">
+				<?php esc_html_e( 'Submit Scoresheet', 'pausatf-membership' ); ?>
+			</button>
+		</p>
+
+		<p class="pausatf-required-note">
+			<span aria-hidden="true">*</span> <?php esc_html_e( 'Required fields', 'pausatf-membership' ); ?>
+		</p>
+	</form>
+
+</div>


### PR DESCRIPTION
## Summary

Converts the legacy Jeff Teeters scripts (2007–2015) from deprecated `mysql_*` PHP to a WordPress plugin. Implements Option A from #37.

- `pausatf_club` CPT — public club directory with shortcode `[pausatf_clubs]`
- `pausatf_member` CPT — private member roster with shortcode `[pausatf_members]` (login required)
- `pausatf_scores` custom table — scoresheet submissions via `[pausatf_scoresheet]`
- WP-Cron daily sync stub — reads from Sport80 CSV export (no public USATF API exists; see #37 comment)
- All output escaped, all input sanitized, `$wpdb->prepare()` throughout, nonce-protected forms

## Research findings (from plugin research)

Athletic.net and MileSplit do not offer embed codes or public APIs — link-only. Sport80 (USATF membership platform) has a club-finder widget API but requires NGB-level configuration. The sync stub uses a CSV-based import path pending stakeholder decision on data source.

## Risk

- Schema only installs on plugin activation — no impact until plugin is activated
- Members CPT is private (`publicly_queryable: false`) — no data exposure
- Does not replace CJT club listing block — coexists until stakeholder decides

## Verification

```bash
# PHP syntax check all files
find wp-content/plugins/pausatf-membership -name '*.php' -exec php -l {} \;
```

## Rollback

Deactivate plugin from WP admin. No changes to existing content.

Closes #37 (Option A branch created; full implementation pending stakeholder sign-off per acceptance criteria).