### PR TITLE
security(terraform): DMARC p=quarantine, restrict HTTP/S to Cloudflare IPs, fix tfvars SSH example

### DIFF
--- a/terraform/environments/cloudflare/main.tf
+++ b/terraform/environments/cloudflare/main.tf
@@ -286,10 +286,10 @@ resource "cloudflare_record" "google_site_verification" {
 resource "cloudflare_record" "dmarc" {
   zone_id = cloudflare_zone.pausatf.id
   name    = "_dmarc"
-  content = "v=DMARC1; p=none;"
+  content = "v=DMARC1; p=quarantine; rua=mailto:admin@pausatf.org; pct=100;"
   type    = "TXT"
   ttl     = 1
-  comment = "DMARC policy (monitoring mode)"
+  comment = "DMARC policy (quarantine enforcement, aggregate reports to admin@pausatf.org)"
 }
 
 resource "cloudflare_record" "dkim_cloudflare" {

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -146,16 +146,34 @@ resource "digitalocean_firewall" "production" {
 
   # HTTP
   inbound_rule {
-    protocol         = "tcp"
-    port_range       = "80"
-    source_addresses = ["0.0.0.0/0", "::/0"]
+    protocol   = "tcp"
+    port_range = "80"
+    source_addresses = [
+      # Cloudflare IPv4 ranges — https://www.cloudflare.com/ips-v4
+      "173.245.48.0/20", "103.21.244.0/22", "103.22.200.0/22", "103.31.4.0/22",
+      "141.101.64.0/18", "108.162.192.0/18", "190.93.240.0/20", "188.114.96.0/20",
+      "197.234.240.0/22", "198.41.128.0/17", "162.158.0.0/15", "104.16.0.0/13",
+      "104.24.0.0/14", "172.64.0.0/13", "131.0.72.0/22",
+      # Cloudflare IPv6 ranges — https://www.cloudflare.com/ips-v6
+      "2400:cb00::/32", "2606:4700::/32", "2803:f800::/32", "2405:b500::/32",
+      "2405:8100::/32", "2a06:98c0::/29", "2c0f:f248::/32"
+    ]
   }
 
   # HTTPS
   inbound_rule {
-    protocol         = "tcp"
-    port_range       = "443"
-    source_addresses = ["0.0.0.0/0", "::/0"]
+    protocol   = "tcp"
+    port_range = "443"
+    source_addresses = [
+      # Cloudflare IPv4 ranges — https://www.cloudflare.com/ips-v4
+      "173.245.48.0/20", "103.21.244.0/22", "103.22.200.0/22", "103.31.4.0/22",
+      "141.101.64.0/18", "108.162.192.0/18", "190.93.240.0/20", "188.114.96.0/20",
+      "197.234.240.0/22", "198.41.128.0/17", "162.158.0.0/15", "104.16.0.0/13",
+      "104.24.0.0/14", "172.64.0.0/13", "131.0.72.0/22",
+      # Cloudflare IPv6 ranges — https://www.cloudflare.com/ips-v6
+      "2400:cb00::/32", "2606:4700::/32", "2803:f800::/32", "2405:b500::/32",
+      "2405:8100::/32", "2a06:98c0::/29", "2c0f:f248::/32"
+    ]
   }
 
   # SSH (restricted)

--- a/terraform/environments/production/terraform.tfvars.example
+++ b/terraform/environments/production/terraform.tfvars.example
@@ -17,9 +17,8 @@ database_size = "db-s-2vcpu-4gb"
 ssh_public_key = "ssh-ed25519 AAAA... your-public-key-here"
 
 ssh_allowed_ips = [
-  # Restrict SSH access to specific IPs
-  # Example: "203.0.113.0/24"
-  "0.0.0.0/0" # WARNING: Allow from anywhere - CHANGE THIS!
+  # Replace with your IP address(es) — never use 0.0.0.0/0 in production
+  # "198.51.100.1/32"   # example: office static IP
 ]
 
 # Monitoring alerts


### PR DESCRIPTION
## Intent
Fixes C2 (DMARC p=none permits email spoofing), M4 (tfvars example ships 0.0.0.0/0 SSH), M6 (origin IP reachable directly, bypassing Cloudflare WAF/DDoS).

## Changes
- `cloudflare/main.tf`: DMARC policy p=none → p=quarantine with aggregate report address
- `production/terraform.tfvars.example`: replace 0.0.0.0/0 SSH example with RFC 5737 documentation CIDR
- `production/main.tf`: restrict HTTP (80) and HTTPS (443) inbound rules to Cloudflare published IP ranges only

## Risk
- **DMARC**: p=quarantine causes failing messages to land in spam rather than inbox. Monitor DMARC aggregate reports at admin@pausatf.org for 30 days, then move to p=reject.
- **Firewall**: Direct access to origin on port 80/443 will be blocked. Any monitoring or health-check tools connecting directly to the origin IP must be updated to use Cloudflare proxy or connect via SSH/VPN instead. Verify the DO monitoring agent (internal VPC) is not affected — it connects on the VPC interface, not the public IP.
- Apply with: `cd terraform/environments/cloudflare && terraform apply` and `cd terraform/environments/production && terraform apply`

## Rollback
Revert commit and re-apply Terraform.