### PR TITLE
security(ansible): harden SSH config, enable UFW/WAF, disable vsftpd

### DIFF
--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,6 +1,6 @@
 [defaults]
 inventory = inventory/hosts.yml
-host_key_checking = False
+host_key_checking = True
 retry_files_enabled = False
 roles_path = roles
 gathering = smart
@@ -21,6 +21,6 @@ become_user = root
 become_ask_pass = False
 
 [ssh_connection]
-ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=no
+ssh_args = -o ControlMaster=auto -o ControlPersist=60s -o StrictHostKeyChecking=accept-new
 pipelining = True
 control_path = /tmp/ansible-ssh-%%h-%%p-%%r

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -53,7 +53,7 @@ cloudflare_always_use_https: true
 
 # Cloudflare Security Settings
 cloudflare_security_level: "medium"
-cloudflare_waf_enabled: false
+cloudflare_waf_enabled: true
 
 # Cloudflare Caching Settings
 cloudflare_cache_level: "aggressive"
@@ -488,7 +488,7 @@ fail2ban_jails:
     enabled: true
 
 # UFW Firewall
-ufw_enabled: false  # Currently disabled on server
+ufw_enabled: true
 ufw_allowed_ports:
   - "22/tcp"
   - "80/tcp"
@@ -555,7 +555,7 @@ sendgrid_subdomain: "em5172"
 # =============================================================================
 
 # FTP (vsftpd)
-vsftpd_enabled: true
+vsftpd_enabled: false
 
 # Postfix (mail)
 postfix_enabled: true

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -27,7 +27,7 @@ all:
       hosts:
         pausatf-stage:
           ansible_host: stage.pausatf.org
-          ansible_user: root
+          ansible_user: github-deploy
           ansible_python_interpreter: /usr/bin/python3
           wordpress_path: /var/www/html
           web_server: openlitespeed
@@ -39,7 +39,7 @@ all:
       hosts:
         pausatf-dev:
           ansible_host: dev.pausatf.org
-          ansible_user: root
+          ansible_user: github-deploy
           ansible_python_interpreter: /usr/bin/python3
           wordpress_path: /var/www/html
           web_server: openlitespeed
@@ -55,5 +55,5 @@ all:
 
   vars:
     # Global variables for all hosts
-    ansible_ssh_common_args: '-o StrictHostKeyChecking=no'
+    ansible_ssh_common_args: '-o StrictHostKeyChecking=accept-new'
     timezone: "America/Los_Angeles"


### PR DESCRIPTION
## Security fixes

- **H4** – SSH strict host key checking: \`StrictHostKeyChecking=no\` → \`accept-new\` in both \`ansible.cfg\` and \`hosts.yml\`; \`host_key_checking = False\` → \`True\` — prevents silent MITM acceptance
- **H5** – Staging/dev \`ansible_user: root\` → \`github-deploy\` — eliminates direct root SSH login for Ansible runs
- **M1** – Enable UFW: \`ufw_enabled: false\` → \`true\` — activates host firewall enforcement
- **M8** – Enable Cloudflare WAF: \`cloudflare_waf_enabled: false\` → \`true\`
- **L2** – Disable vsftpd: \`vsftpd_enabled: true\` → \`false\` — removes unused FTP attack surface

Files changed:
- \`ansible/ansible.cfg\`
- \`ansible/inventory/hosts.yml\`
- \`ansible/group_vars/all.yml\`

**Note on H5**: staging and dev hosts must have a \`github-deploy\` user created with sudo access before running playbooks against those environments. Production already uses \`github-deploy\`.

Verification: \`ansible-playbook --check\` passes; \`ansible-lint\` clean.

Rollback: revert this PR; re-run playbook to restore prior Ansible config.