### PR TITLE
fix(apache): serve legacy /data/ via Alias to pre-WordPress content tree

### DIFF
--- a/ansible/roles/apache/tasks/main.yml
+++ b/ansible/roles/apache/tasks/main.yml
@@ -208,6 +208,22 @@
     mode: '0644'
   when: wordpress_installs | selectattr('path', 'equalto', '/var/www/html') | list | length > 0
 
+- name: Deploy legacy /data/ alias configuration
+  template:
+    src: legacy-data.conf.j2
+    dest: /etc/apache2/conf-available/legacy-data.conf
+    owner: root
+    group: root
+    mode: '0644'
+  notify: Reload Apache
+
+- name: Enable legacy /data/ alias
+  file:
+    src: /etc/apache2/conf-available/legacy-data.conf
+    dest: /etc/apache2/conf-enabled/legacy-data.conf
+    state: link
+  notify: Reload Apache
+
 - name: Ensure Apache is started and enabled
   service:
     name: apache2

--- a/ansible/roles/apache/templates/legacy-data.conf.j2
+++ b/ansible/roles/apache/templates/legacy-data.conf.j2
@@ -1,0 +1,14 @@
+# Serve pre-WordPress /data/ content tree at www.pausatf.org/data/.
+# This directory predates the WordPress migration. It must be served
+# directly by Apache — the WordPress rewrite rule's !-d guard only fires
+# if the path resolves to a real directory inside DocumentRoot, which it
+# does not (data/ lives in the legacy tree, not /var/www/html/).
+{% set legacy_public = legacy_sites | selectattr('name', 'equalto', 'legacy-public') | map(attribute='path') | first %}
+
+Alias /data {{ legacy_public }}/data
+
+<Directory {{ legacy_public }}/data>
+    Options FollowSymLinks
+    AllowOverride All
+    Require all granted
+</Directory>


### PR DESCRIPTION
## Problem

`/data/` URLs (e.g. `/data/2025/RRResults2025.html`, `/data/members.php`) are routing to WordPress and returning a 404 page.

**Root cause**: `/data/` content lives at `/var/www/legacy/public_html/data/`, which is outside the WordPress `DocumentRoot` (`/var/www/html/`). The WordPress rewrite rule's `!-d` guard only bypasses rewriting when the requested path resolves to a real directory _inside_ DocumentRoot — since `/var/www/html/data/` does not exist, the `!-d` condition is true and all `/data/` requests get passed to `index.php`.

This likely broke when the Apache vhost was redeployed (PR #63), overwriting any manually-configured Alias that had previously served this path.

## Fix

Adds `conf-available/legacy-data.conf` via a new Ansible template:

```apache
Alias /data /var/www/legacy/public_html/data

<Directory /var/www/legacy/public_html/data>
    Options FollowSymLinks
    AllowOverride All
    Require all granted
</Directory>
```

Apache resolves the Alias before the WordPress `.htaccess` rewrite fires, so `/data/` is served directly from the legacy content tree.

## Immediate manual fix (before Ansible run)

SSH to the server and run:

```bash
cat > /etc/apache2/conf-available/legacy-data.conf << 'CONF'
Alias /data /var/www/legacy/public_html/data

<Directory /var/www/legacy/public_html/data>
    Options FollowSymLinks
    AllowOverride All
    Require all granted
</Directory>
CONF

a2enconf legacy-data && apache2ctl configtest && service apache2 reload
```

Verify: `curl -I https://www.pausatf.org/data/2025/RRResults2025.html` should return 200.

Rollback: `a2disconf legacy-data && service apache2 reload`