### PR TITLE
fix(ansible): correct WordPress secrets assertion to check vault vars

### DIFF
--- a/ansible/roles/wordpress/tasks/main.yml
+++ b/ansible/roles/wordpress/tasks/main.yml
@@ -3,19 +3,19 @@
 # - uses WP-CLI to manage core, plugins, and themes
 # - honors per-install settings in group_vars
 
-- name: Assert WordPress secrets are configured
+- name: Assert WordPress vault secrets are configured
   assert:
     that:
-      - wordpress_db_password | length > 0
-      - wordpress_auth_key | length > 0
-      - wordpress_secure_auth_key | length > 0
-      - wordpress_logged_in_key | length > 0
-      - wordpress_nonce_key | length > 0
-      - wordpress_auth_salt | length > 0
-      - wordpress_secure_auth_salt | length > 0
-      - wordpress_logged_in_salt | length > 0
-      - wordpress_nonce_salt | length > 0
-    fail_msg: "WordPress secrets must be set via Ansible vault — check vault_wp_main_* variables"
+      - vault_wp_main_db_password is defined and vault_wp_main_db_password | length > 0
+      - vault_wp_main_auth_key is defined and vault_wp_main_auth_key | length > 0
+      - vault_wp_main_secure_auth_key is defined and vault_wp_main_secure_auth_key | length > 0
+      - vault_wp_main_logged_in_key is defined and vault_wp_main_logged_in_key | length > 0
+      - vault_wp_main_nonce_key is defined and vault_wp_main_nonce_key | length > 0
+      - vault_wp_main_auth_salt is defined and vault_wp_main_auth_salt | length > 0
+      - vault_wp_main_secure_auth_salt is defined and vault_wp_main_secure_auth_salt | length > 0
+      - vault_wp_main_logged_in_salt is defined and vault_wp_main_logged_in_salt | length > 0
+      - vault_wp_main_nonce_salt is defined and vault_wp_main_nonce_salt | length > 0
+    fail_msg: "WordPress secrets must be set via Ansible vault — vault_wp_main_* variables are missing or empty"
 
 - name: Ensure WP-CLI is installed
   get_url:


### PR DESCRIPTION
## Problem

PR #65 added a pre-task assertion to the WordPress role that checked role-default variables (`wordpress_db_password`, `wordpress_auth_key`, etc.). These variables default to `""` in `roles/wordpress/defaults/main.yml` and are **never populated from the vault** — the vault variables (`vault_wp_main_*`) feed into `wordpress_installs[*].db_password`, not flat role-level vars.

Result: every deploy run has been failing at `Assert WordPress secrets are configured` with exit code 2, even when the vault is correctly populated.

## Fix

Assert against the actual vault variables (`vault_wp_main_db_password`, etc.) which are guaranteed to be defined and non-empty when the vault is decrypted correctly.

Verification: re-run `Deploy to Production` — assert passes when `ANSIBLE_VAULT_FILE` secret contains a correctly populated vault.

Rollback: revert this PR to restore the (broken) flat-var assertion.