### PR TITLE
fix(backup): include legacy /data/ content in nightly backup

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -529,6 +529,8 @@ backup_items:
   - name: "wordpress-main"
     path: "/var/www/html"
     db_name: "wordpress"
+  - name: "legacy-data"
+    path: "/var/www/legacy/public_html/data"
 
 # =============================================================================
 # EMAIL (Google Workspace)

--- a/ansible/roles/monitoring/templates/backup-wordpress.sh.j2
+++ b/ansible/roles/monitoring/templates/backup-wordpress.sh.j2
@@ -36,6 +36,17 @@ log "{{ wp.name }} backup complete"
 
 {% endfor %}
 
+{% set file_only_items = backup_items | rejectattr('db_name', 'defined') | list %}
+{% if file_only_items %}
+# Backup non-WordPress file paths (no database)
+{% for item in file_only_items %}
+log "Backing up {{ item.name }} (files only)..."
+tar -czf "$BACKUP_DIR/{{ item.name }}-files-$DATE.tar.gz" \
+    -C "$(dirname {{ item.path }})" "$(basename {{ item.path }})"
+log "{{ item.name }} backup complete"
+
+{% endfor %}
+{% endif %}
 # Cleanup old backups
 log "Cleaning up backups older than $RETENTION_DAYS days..."
 find "$BACKUP_DIR" -name "*.gz" -mtime +$RETENTION_DAYS -delete


### PR DESCRIPTION
## Problem

`/var/www/legacy/public_html/data` (race results, member data, served at `www.pausatf.org/data/`) was not in `backup_items` and was never included in the nightly backup script.

## Fix

- Adds `legacy-data` entry to `backup_items` in `group_vars/all.yml`
- Adds a file-only backup loop in `backup-wordpress.sh.j2` for `backup_items` entries without a `db_name` field — these get tar'd directly, no mysqldump

Backup output: `legacy-data-files-YYYYMMDD-HHMMSS.tar.gz` in `{{ backup_destination }}`, rotated by the existing retention policy.

Rollback: revert this PR; next Ansible run removes the legacy-data entry and loop.