### PR TITLE
fix(monitoring): schedule nightly backup via cron

### DIFF
--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -37,3 +37,14 @@
     owner: root
     group: root
     mode: '0700'
+
+- name: Schedule nightly WordPress backup
+  cron:
+    name: "WordPress backup"
+    minute: "{{ (backup_schedule.split(' '))[0] }}"
+    hour: "{{ (backup_schedule.split(' '))[1] }}"
+    day: "{{ (backup_schedule.split(' '))[2] }}"
+    month: "{{ (backup_schedule.split(' '))[3] }}"
+    weekday: "{{ (backup_schedule.split(' '))[4] }}"
+    job: "/usr/local/sbin/backup-wordpress.sh >> /var/log/wordpress-backup.log 2>&1"
+    state: "{{ 'present' if backup_enabled | default(true) else 'absent' }}"


### PR DESCRIPTION
## Problem

\`backup_schedule: "0 2 * * *"\` was defined in \`group_vars/all.yml\` and the backup script was deployed to \`/usr/local/sbin/backup-wordpress.sh\`, but the monitoring role never installed a cron job. Backups have never run — no log file, no backup files on server.

## Fix

Adds a \`cron\` task that reads \`backup_schedule\` and \`backup_enabled\` from group_vars and installs/removes the job accordingly.

## Verification

\`\`\`bash
# After deploy, confirm cron installed:
ssh root@ftp.pausatf.org "crontab -l | grep backup"
# Run manually to confirm it works:
ssh root@ftp.pausatf.org "/usr/local/sbin/backup-wordpress.sh && tail /var/log/wordpress-backup.log"
\`\`\`