### PR TITLE
fix(ci): restore --snapshot-name for doctl droplet-action snapshot

### DIFF
--- a/.github/workflows/do-nightly-snapshot.yml
+++ b/.github/workflows/do-nightly-snapshot.yml
@@ -26,5 +26,5 @@ jobs:
             echo "DO_PROD_DROPLET_ID secret is required" >&2
             exit 1
           fi
-          # --snapshot-name removed: flag unsupported in doctl v1.140+
-          doctl compute droplet-action snapshot "$DROPLET_ID"
+          doctl compute droplet-action snapshot "$DROPLET_ID" \
+            --snapshot-name "prod-nightly-$(date -u +%Y%m%d-%H%M%S)"


### PR DESCRIPTION
Required flag omitted in prior fix. doctl v1.150 requires --snapshot-name for droplet-action snapshot.