### PR TITLE
fix(infra): implement 6 architecture improvements

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -85,3 +85,31 @@ jobs:
       - name: Syntax-check site.yml
         working-directory: ansible
         run: ansible-playbook --syntax-check site.yml
+
+  molecule:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        role:
+          - common
+          - wordpress
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4
+
+      - name: Setup Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install ansible-core==2.17.5 molecule molecule-plugins[docker] docker
+
+      - name: Run Molecule
+        working-directory: ansible/roles/${{ matrix.role }}
+        run: molecule test
+        env:
+          PY_COLORS: '1'
+          ANSIBLE_FORCE_COLOR: '1'

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -1,39 +1,24 @@
 ---
-# PAUSATF Global Variables
-# ========================
-# Complete configuration from server audit of ftp.pausatf.org
-# Generated: 2025-12-06
+# Global Defaults — all environments
+# ====================================
+# Variables here apply to every host (production, staging, dev) unless a
+# more-specific group_vars file overrides them.
+#
+# Production-specific values (droplet IDs, DNS records, WP install block,
+# theme/plugin lists, backup paths) live in:
+#   ansible/group_vars/production/main.yml
+#
+# Per-environment overrides (staging, dev) live in:
+#   ansible/group_vars/staging.yml
+#   ansible/group_vars/dev.yml
 
 # =============================================================================
 # INFRASTRUCTURE / HOSTING
 # =============================================================================
-
-# DigitalOcean Configuration
 hosting_provider: "digitalocean"
-digitalocean_droplet_id: "{{ vault_digitalocean_droplet_id }}"
-digitalocean_droplet_name: "pausatforg20230516-primary"
-digitalocean_region: "sfo2"
-digitalocean_region_name: "San Francisco 2"
-digitalocean_size: "s-4vcpu-8gb"
-digitalocean_vcpus: 4
-digitalocean_memory_mb: 8192
-digitalocean_disk_gb: 160
-digitalocean_image: "pausatf.org 2023-05-16"
-digitalocean_public_ip: "64.225.40.54"
-digitalocean_private_ip: "10.138.0.2"
-digitalocean_vpc_uuid: "4ee39499-dc85-11e8-9f23-3cfdfea9fff1"
-digitalocean_features:
-  - backups
-  - droplet_agent
-  - private_networking
-digitalocean_tags:
-  - test
-  - pausatf
-  - production
-  - web
 digitalocean_api_token: "{{ vault_digitalocean_api_token }}"
 
-# Cloudflare DNS/CDN Configuration
+# Cloudflare zone/API — shared across environments
 cloudflare_enabled: true
 cloudflare_zone: "pausatf.org"
 cloudflare_zone_id: "{{ vault_cloudflare_zone_id }}"
@@ -59,34 +44,10 @@ cloudflare_waf_enabled: true
 cloudflare_cache_level: "aggressive"
 cloudflare_browser_cache_ttl: 0
 
-# DNS Records managed by Cloudflare
-cloudflare_dns_records:
-  - name: "@"
-    type: "A"
-    content: "64.225.40.54"
-    proxied: true
-  - name: "www"
-    type: "A"
-    content: "64.225.40.54"
-    proxied: true
-  - name: "ftp"
-    type: "A"
-    content: "64.225.40.54"
-    proxied: false
-  - name: "mail"
-    type: "A"
-    content: "64.225.40.54"
-    proxied: false
-  - name: "monitor"
-    type: "A"
-    content: "64.225.40.54"
-    proxied: false
-
 # =============================================================================
 # SYSTEM
 # =============================================================================
 timezone: "America/Los_Angeles"
-hostname: "pausatf-prod"
 os_distribution: "ubuntu"
 os_version: "24.04"
 os_codename: "noble"
@@ -204,194 +165,6 @@ mysql_managed: true
 mysql_port: 25060  # DO Managed MySQL default port
 
 # =============================================================================
-# WORDPRESS INSTALLATIONS
-# =============================================================================
-wordpress_installs:
-  # Main PAUSATF website
-  - name: "pausatf-main"
-    domain: "www.pausatf.org"
-    aliases:
-      - "pausatf.org"
-    path: "/var/www/html"
-    db_name: "wordpress"
-    db_user: "wordpress"
-    db_password: "{{ vault_wp_main_db_password }}"
-    db_host: "localhost"
-    table_prefix: "wp_"
-    wp_version: "6.8.3"
-    wp_memory_limit: "256M"
-    wp_max_memory_limit: "512M"
-    ssl_enabled: true
-    ssl_certificate: "/etc/letsencrypt/live/pausatf.org/fullchain.pem"
-    ssl_certificate_key: "/etc/letsencrypt/live/pausatf.org/privkey.pem"
-    active_theme: "TheSource-child"
-    cron_enabled: true
-    debug_mode: false
-    disallow_file_edit: true
-    disallow_file_mods: false
-    auto_update_core: "minor"
-    fs_method: "direct"
-    manage_wp_config: true
-    # Auth keys and salts
-    auth_key: "{{ vault_wp_main_auth_key }}"
-    secure_auth_key: "{{ vault_wp_main_secure_auth_key }}"
-    logged_in_key: "{{ vault_wp_main_logged_in_key }}"
-    nonce_key: "{{ vault_wp_main_nonce_key }}"
-    auth_salt: "{{ vault_wp_main_auth_salt }}"
-    secure_auth_salt: "{{ vault_wp_main_secure_auth_salt }}"
-    logged_in_salt: "{{ vault_wp_main_logged_in_salt }}"
-    nonce_salt: "{{ vault_wp_main_nonce_salt }}"
-
-# =============================================================================
-# WORDPRESS THEMES (Main Site)
-# =============================================================================
-wp_main_themes:
-  # Active theme
-  - name: "TheSource-child"
-    status: "active"
-    version: "0.2"
-    parent: "TheSource"
-    author: "Sean Dulany | SMDdesigns"
-    auto_update: false
-  # Parent theme (required)
-  - name: "TheSource"
-    status: "parent"
-    version: "4.8.13"
-    author: "Elegant Themes"
-    auto_update: true
-  # Inactive themes (kept for reference/fallback)
-  - name: "oceanwp"
-    status: "inactive"
-    version: "4.1.4"
-    auto_update: true
-  - name: "pausatf-oceanwp-child-v2"
-    status: "inactive"
-    version: "1.1.0"
-    parent: "oceanwp"
-    auto_update: false
-  - name: "pausatf-oceanwp-child"
-    status: "inactive"
-    version: "1.0.0"
-    parent: "oceanwp"
-    auto_update: false
-  - name: "pausatf-oceanwp-theme"
-    status: "inactive"
-    version: "1.0.0"
-    parent: "oceanwp"
-    auto_update: false
-
-# =============================================================================
-# WORDPRESS PLUGINS (Main Site)
-# =============================================================================
-wp_main_plugins:
-  # Active plugins
-  - name: "accordions"
-    slug: "accordions"
-    status: "active"
-    version: "2.3.17"
-    auto_update: true
-    description: "Accordion grid for WordPress"
-  - name: "category-posts"
-    slug: "category-posts"
-    status: "active"
-    version: "4.9.22"
-    auto_update: true
-    description: "Widget showing recent posts from a category"
-  - name: "classic-editor"
-    slug: "classic-editor"
-    status: "active"
-    version: "1.6.7"
-    auto_update: true
-    description: "Restores the classic WordPress editor"
-  - name: "cloudflare"
-    slug: "cloudflare"
-    status: "active"
-    version: "4.13.0"
-    auto_update: true
-    description: "Cloudflare integration plugin"
-  - name: "contact-form-7"
-    slug: "contact-form-7"
-    status: "active"
-    version: "6.1.4"
-    auto_update: true
-    description: "Contact form management"
-  - name: "jetpack"
-    slug: "jetpack"
-    status: "active"
-    version: "15.3.1"
-    auto_update: true
-    description: "WordPress.com features for self-hosted sites"
-  - name: "media-library-plus"
-    slug: "media-library-plus"
-    status: "active"
-    version: "8.3.6"
-    auto_update: true
-    description: "Enhanced media library with folders"
-  - name: "ml-slider"
-    slug: "ml-slider"
-    status: "active"
-    version: "3.103.0"
-    auto_update: true
-    description: "Slider and carousel plugin"
-  - name: "tablepress-premium"
-    slug: "tablepress-premium"
-    status: "active"
-    version: "3.2.5"
-    auto_update: true
-    description: "Table management (premium)"
-  - name: "updraftplus"
-    slug: "updraftplus"
-    status: "active"
-    version: "2.25.9.0"
-    auto_update: true
-    description: "Backup and restore plugin"
-  - name: "widget-logic"
-    slug: "widget-logic"
-    status: "active"
-    version: "6.02"
-    auto_update: true
-    description: "Control widgets with conditional tags"
-  - name: "widget-options"
-    slug: "widget-options"
-    status: "active"
-    version: "4.1.3"
-    auto_update: true
-    description: "Extended widget control options"
-  - name: "wpforms-lite"
-    slug: "wpforms-lite"
-    status: "active"
-    version: "1.9.8.4"
-    auto_update: true
-    description: "Form builder plugin"
-  - name: "wp-mail-smtp"
-    slug: "wp-mail-smtp"
-    status: "active"
-    version: "4.7.1"
-    auto_update: true
-    description: "SMTP email configuration"
-  # Inactive plugins
-  - name: "ocean-extra"
-    slug: "ocean-extra"
-    status: "inactive"
-    version: "2.5.2"
-    auto_update: false
-    description: "OceanWP theme extras"
-
-# Must-Use Plugins (loaded automatically)
-wp_main_mu_plugins:
-  - name: "fix-translations"
-    version: "1.0"
-    description: "Fixes translation loading issues"
-  - name: "wp-fail2ban"
-    version: "3.5.3"
-    description: "Fail2ban integration for WordPress"
-
-# Drop-ins
-wp_main_dropins:
-  - name: "advanced-cache.php"
-    description: "Advanced caching drop-in"
-
-# =============================================================================
 # WP-CLI CONFIGURATION
 # =============================================================================
 wpcli_enabled: true
@@ -506,12 +279,6 @@ backup_enabled: true
 backup_retention_days: 30
 backup_destination: "/var/backups/wordpress"
 backup_schedule: "0 2 * * *"  # 2 AM daily
-backup_items:
-  - name: "wordpress-main"
-    path: "/var/www/html"
-    db_name: "wordpress"
-  - name: "legacy-data"
-    path: "/var/www/legacy/public_html/data"
 
 # =============================================================================
 # EMAIL (Google Workspace)

--- a/ansible/group_vars/production/main.yml
+++ b/ansible/group_vars/production/main.yml
@@ -1,0 +1,261 @@
+---
+# Production-specific variables
+# ==============================
+# This file holds values that are specific to the production environment.
+# Truly global defaults (shared across all envs) live in group_vars/all.yml.
+# Ansible merges both automatically when targeting the production group.
+
+# =============================================================================
+# DIGITALOCEAN — PRODUCTION DROPLET
+# =============================================================================
+# These values describe the live production droplet and must not bleed into
+# dev/staging, which use different (or no) DigitalOcean resources.
+digitalocean_droplet_id: "{{ vault_digitalocean_droplet_id }}"
+digitalocean_droplet_name: "pausatforg20230516-primary"
+digitalocean_region: "sfo2"
+digitalocean_region_name: "San Francisco 2"
+digitalocean_size: "s-4vcpu-8gb"
+digitalocean_vcpus: 4
+digitalocean_memory_mb: 8192
+digitalocean_disk_gb: 160
+digitalocean_image: "pausatf.org 2023-05-16"
+digitalocean_public_ip: "64.225.40.54"
+digitalocean_private_ip: "10.138.0.2"
+digitalocean_vpc_uuid: "4ee39499-dc85-11e8-9f23-3cfdfea9fff1"
+digitalocean_features:
+  - backups
+  - droplet_agent
+  - private_networking
+digitalocean_tags:
+  - test
+  - pausatf
+  - production
+  - web
+
+# =============================================================================
+# CLOUDFLARE — PRODUCTION DNS RECORDS
+# =============================================================================
+# These A records point to the production IP. Dev/staging use different targets.
+cloudflare_dns_records:
+  - name: "@"
+    type: "A"
+    content: "64.225.40.54"
+    proxied: true
+  - name: "www"
+    type: "A"
+    content: "64.225.40.54"
+    proxied: true
+  - name: "ftp"
+    type: "A"
+    content: "64.225.40.54"
+    proxied: false
+  - name: "mail"
+    type: "A"
+    content: "64.225.40.54"
+    proxied: false
+  - name: "monitor"
+    type: "A"
+    content: "64.225.40.54"
+    proxied: false
+
+# =============================================================================
+# SYSTEM — PRODUCTION HOSTNAME
+# =============================================================================
+hostname: "pausatf-prod"
+
+# =============================================================================
+# WORDPRESS — PRODUCTION INSTALL
+# =============================================================================
+# Full install definition with production DB, SSL paths, and vault-sourced
+# auth keys. Dev/staging override this block entirely in their own group_vars.
+wordpress_installs:
+  - name: "pausatf-main"
+    domain: "www.pausatf.org"
+    aliases:
+      - "pausatf.org"
+    path: "/var/www/html"
+    db_name: "wordpress"
+    db_user: "wordpress"
+    db_password: "{{ vault_wp_main_db_password }}"
+    db_host: "localhost"
+    table_prefix: "wp_"
+    wp_version: "6.8.3"
+    wp_memory_limit: "256M"
+    wp_max_memory_limit: "512M"
+    ssl_enabled: true
+    ssl_certificate: "/etc/letsencrypt/live/pausatf.org/fullchain.pem"
+    ssl_certificate_key: "/etc/letsencrypt/live/pausatf.org/privkey.pem"
+    active_theme: "TheSource-child"
+    cron_enabled: true
+    debug_mode: false
+    disallow_file_edit: true
+    disallow_file_mods: false
+    auto_update_core: "minor"
+    fs_method: "direct"
+    manage_wp_config: true
+    # Auth keys and salts — sourced from vault; never hardcode
+    auth_key: "{{ vault_wp_main_auth_key }}"
+    secure_auth_key: "{{ vault_wp_main_secure_auth_key }}"
+    logged_in_key: "{{ vault_wp_main_logged_in_key }}"
+    nonce_key: "{{ vault_wp_main_nonce_key }}"
+    auth_salt: "{{ vault_wp_main_auth_salt }}"
+    secure_auth_salt: "{{ vault_wp_main_secure_auth_salt }}"
+    logged_in_salt: "{{ vault_wp_main_logged_in_salt }}"
+    nonce_salt: "{{ vault_wp_main_nonce_salt }}"
+
+# =============================================================================
+# WORDPRESS THEMES (production site)
+# =============================================================================
+wp_main_themes:
+  - name: "TheSource-child"
+    status: "active"
+    version: "0.2"
+    parent: "TheSource"
+    author: "Sean Dulany | SMDdesigns"
+    auto_update: false
+  - name: "TheSource"
+    status: "parent"
+    version: "4.8.13"
+    author: "Elegant Themes"
+    auto_update: true
+  - name: "oceanwp"
+    status: "inactive"
+    version: "4.1.4"
+    auto_update: true
+  - name: "pausatf-oceanwp-child-v2"
+    status: "inactive"
+    version: "1.1.0"
+    parent: "oceanwp"
+    auto_update: false
+  - name: "pausatf-oceanwp-child"
+    status: "inactive"
+    version: "1.0.0"
+    parent: "oceanwp"
+    auto_update: false
+  - name: "pausatf-oceanwp-theme"
+    status: "inactive"
+    version: "1.0.0"
+    parent: "oceanwp"
+    auto_update: false
+
+# =============================================================================
+# WORDPRESS PLUGINS (production site)
+# =============================================================================
+wp_main_plugins:
+  # Active plugins
+  - name: "accordions"
+    slug: "accordions"
+    status: "active"
+    version: "2.3.17"
+    auto_update: true
+    description: "Accordion grid for WordPress"
+  - name: "category-posts"
+    slug: "category-posts"
+    status: "active"
+    version: "4.9.22"
+    auto_update: true
+    description: "Widget showing recent posts from a category"
+  - name: "classic-editor"
+    slug: "classic-editor"
+    status: "active"
+    version: "1.6.7"
+    auto_update: true
+    description: "Restores the classic WordPress editor"
+  - name: "cloudflare"
+    slug: "cloudflare"
+    status: "active"
+    version: "4.13.0"
+    auto_update: true
+    description: "Cloudflare integration plugin"
+  - name: "contact-form-7"
+    slug: "contact-form-7"
+    status: "active"
+    version: "6.1.4"
+    auto_update: true
+    description: "Contact form management"
+  - name: "jetpack"
+    slug: "jetpack"
+    status: "active"
+    version: "15.3.1"
+    auto_update: true
+    description: "WordPress.com features for self-hosted sites"
+  - name: "media-library-plus"
+    slug: "media-library-plus"
+    status: "active"
+    version: "8.3.6"
+    auto_update: true
+    description: "Enhanced media library with folders"
+  - name: "ml-slider"
+    slug: "ml-slider"
+    status: "active"
+    version: "3.103.0"
+    auto_update: true
+    description: "Slider and carousel plugin"
+  - name: "tablepress-premium"
+    slug: "tablepress-premium"
+    status: "active"
+    version: "3.2.5"
+    auto_update: true
+    description: "Table management (premium)"
+  - name: "updraftplus"
+    slug: "updraftplus"
+    status: "active"
+    version: "2.25.9.0"
+    auto_update: true
+    description: "Backup and restore plugin"
+  - name: "widget-logic"
+    slug: "widget-logic"
+    status: "active"
+    version: "6.02"
+    auto_update: true
+    description: "Control widgets with conditional tags"
+  - name: "widget-options"
+    slug: "widget-options"
+    status: "active"
+    version: "4.1.3"
+    auto_update: true
+    description: "Extended widget control options"
+  - name: "wpforms-lite"
+    slug: "wpforms-lite"
+    status: "active"
+    version: "1.9.8.4"
+    auto_update: true
+    description: "Form builder plugin"
+  - name: "wp-mail-smtp"
+    slug: "wp-mail-smtp"
+    status: "active"
+    version: "4.7.1"
+    auto_update: true
+    description: "SMTP email configuration"
+  # Inactive plugins
+  - name: "ocean-extra"
+    slug: "ocean-extra"
+    status: "inactive"
+    version: "2.5.2"
+    auto_update: false
+    description: "OceanWP theme extras"
+
+# Must-Use Plugins (loaded automatically)
+wp_main_mu_plugins:
+  - name: "fix-translations"
+    version: "1.0"
+    description: "Fixes translation loading issues"
+  - name: "wp-fail2ban"
+    version: "3.5.3"
+    description: "Fail2ban integration for WordPress"
+
+# Drop-ins
+wp_main_dropins:
+  - name: "advanced-cache.php"
+    description: "Advanced caching drop-in"
+
+# =============================================================================
+# BACKUP — PRODUCTION PATHS
+# =============================================================================
+# References production filesystem paths; dev/staging use different layouts.
+backup_items:
+  - name: "wordpress-main"
+    path: "/var/www/html"
+    db_name: "wordpress"
+  - name: "legacy-data"
+    path: "/var/www/legacy/public_html/data"

--- a/ansible/roles/wordpress/tasks/main.yml
+++ b/ansible/roles/wordpress/tasks/main.yml
@@ -17,6 +17,19 @@
       - vault_wp_main_nonce_salt is defined and vault_wp_main_nonce_salt | length > 0
     fail_msg: "WordPress secrets must be set via Ansible vault — vault_wp_main_* variables are missing or empty"
 
+- name: Assert WordPress auth keys are wired through wordpress_installs
+  assert:
+    that:
+      - wordpress_installs[0].auth_key | default('') | length > 0
+      - wordpress_installs[0].secure_auth_key | default('') | length > 0
+      - wordpress_installs[0].logged_in_key | default('') | length > 0
+      - wordpress_installs[0].nonce_key | default('') | length > 0
+    fail_msg: "wordpress_installs[].auth keys must be wired from vault variables"
+  when:
+    - wordpress_installs is defined
+    - wordpress_installs | length > 0
+    - wordpress_installs[0].manage_wp_config | default(false)
+
 - name: Ensure WP-CLI is installed
   get_url:
     url: https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -22,49 +22,90 @@
   gather_facts: yes
   become: yes
 
-  roles:
-    # PHP — mod_php (legacy) or PHP-FPM (new)
-    - role: php
-      when:
-        - web_server | default('apache') == 'apache'
-        - not (use_php_fpm | default(false))
+  tasks:
+    - name: Deploy web stack
+      block:
+        - name: Include PHP role (mod_php)
+          include_role:
+            name: php
+          when:
+            - web_server | default('apache') == 'apache'
+            - not (use_php_fpm | default(false))
 
-    - role: php-fpm
-      when:
-        - web_server | default('apache') == 'apache'
-        - use_php_fpm | default(false)
+        - name: Include PHP-FPM role
+          include_role:
+            name: php-fpm
+          when:
+            - web_server | default('apache') == 'apache'
+            - use_php_fpm | default(false)
 
-    - role: apache
-      when: web_server | default('apache') == 'apache'
+        - name: Include Apache role
+          include_role:
+            name: apache
+          when: web_server | default('apache') == 'apache'
 
-    # OpenLiteSpeed path (staging/dev)
-    - role: lsphp
-      when: web_server | default('apache') == 'openlitespeed'
+        - name: Include OpenLiteSpeed PHP role
+          include_role:
+            name: lsphp
+          when: web_server | default('apache') == 'openlitespeed'
 
-    - role: openlitespeed
-      when: web_server | default('apache') == 'openlitespeed'
+        - name: Include OpenLiteSpeed role
+          include_role:
+            name: openlitespeed
+          when: web_server | default('apache') == 'openlitespeed'
 
-    # TLS certificates via Let's Encrypt DNS-01
-    - role: certbot
-      when: certbot_enabled | default(false)
+        - name: Include Certbot role
+          include_role:
+            name: certbot
+          when: certbot_enabled | default(false)
 
-    - role: mysql
-      when: mysql_enabled | default(true)
+        - name: Include MySQL role
+          include_role:
+            name: mysql
+          when: mysql_enabled | default(true)
 
-    # Redis object cache
-    - role: redis
-      when: redis_enabled | default(false)
+        - name: Include Redis role
+          include_role:
+            name: redis
+          when: redis_enabled | default(false)
 
-    - role: fail2ban
+        - name: Include Fail2ban role
+          include_role:
+            name: fail2ban
 
-    - role: wordpress
-      when: wordpress_enabled | default(true)
+        - name: Include WordPress role
+          include_role:
+            name: wordpress
+          when: wordpress_enabled | default(true)
 
-    - role: cloudflare
-      when: cloudflare_enabled | default(false)
+        - name: Include Cloudflare role
+          include_role:
+            name: cloudflare
+          when: cloudflare_enabled | default(false)
 
-    - role: newrelic
-      when: newrelic_enabled | default(false)
+        - name: Include New Relic role
+          include_role:
+            name: newrelic
+          when: newrelic_enabled | default(false)
+
+      rescue:
+        - name: Web stack deployment failed
+          debug:
+            msg: >
+              DEPLOYMENT FAILED on {{ inventory_hostname }}.
+              Role: {{ ansible_failed_task.name | default('unknown') }}.
+              Error: {{ ansible_failed_result.msg | default('unknown error') }}.
+              Manual intervention required. Check service status and logs.
+
+        - name: Verify web server is still running
+          service:
+            name: "{{ 'apache2' if web_server | default('apache') == 'apache' else 'lsws' }}"
+            state: started
+          ignore_errors: yes
+
+        - name: Fail the play after rescue
+          fail:
+            msg: "Deployment failed. Web server recovery attempted. Review errors above."
 
 - name: Configure monitoring
   hosts: all

--- a/scripts/terraform-wrapper.sh
+++ b/scripts/terraform-wrapper.sh
@@ -26,13 +26,15 @@ usage() {
 Usage: $0 <environment> <action>
 
 Arguments:
-  environment    Environment to target (production, staging)
-  action         Terraform action (plan, apply, destroy, output)
+  environment    Environment to target (production, staging, dev, cloudflare, github)
+  action         Terraform action (plan, apply, destroy, output, init, validate)
 
 Examples:
   $0 production plan
   $0 staging apply
   $0 production output
+  $0 cloudflare plan
+  $0 github apply
 
 EOF
     exit 1
@@ -40,8 +42,8 @@ EOF
 
 # Validate environment
 validate_environment() {
-    if [[ ! "$ENVIRONMENT" =~ ^(production|staging)$ ]]; then
-        echo -e "${RED}Error: Invalid environment. Must be 'production' or 'staging'${NC}"
+    if [[ ! "$ENVIRONMENT" =~ ^(production|staging|dev|cloudflare|github)$ ]]; then
+        echo -e "${RED}Error: Invalid environment. Must be one of: production, staging, dev, cloudflare, github${NC}"
         usage
     fi
 }
@@ -73,6 +75,35 @@ check_env_vars() {
             echo -e "${YELLOW}Warning: Environment variable $var is not set${NC}"
         fi
     done
+}
+
+# Advisory lock — prevents concurrent local runs per environment.
+# CI relies on GitHub Actions concurrency groups instead.
+LOCK_DIR="${HOME}/.terraform-locks"
+LOCK_FILE="${LOCK_DIR}/pausatf-${ENVIRONMENT:-unknown}.lock"
+
+acquire_lock() {
+    mkdir -p "$LOCK_DIR"
+    if [ -f "$LOCK_FILE" ]; then
+        local lock_pid
+        lock_pid=$(cat "$LOCK_FILE" 2>/dev/null || echo "unknown")
+        local lock_age
+        lock_age=$(( $(date +%s) - $(stat -f %m "$LOCK_FILE" 2>/dev/null || stat -c %Y "$LOCK_FILE" 2>/dev/null || echo 0) ))
+        if [ "$lock_age" -gt 3600 ]; then
+            echo -e "${YELLOW}Warning: Stale lock found (${lock_age}s old, PID $lock_pid). Removing.${NC}"
+            rm -f "$LOCK_FILE"
+        else
+            echo -e "${RED}Error: Terraform lock held for $ENVIRONMENT (PID $lock_pid, ${lock_age}s ago)${NC}"
+            echo -e "${RED}If this is stale, remove: rm $LOCK_FILE${NC}"
+            exit 1
+        fi
+    fi
+    echo $$ > "$LOCK_FILE"
+    trap 'release_lock' EXIT
+}
+
+release_lock() {
+    rm -f "$LOCK_FILE"
 }
 
 # Run terraform command
@@ -127,6 +158,7 @@ main() {
     validate_action
     check_dependencies
     check_env_vars
+    acquire_lock
     run_terraform
 
     echo -e "${GREEN}==>${NC} Terraform $ACTION completed successfully"

--- a/terraform/environments/cloudflare/main.tf
+++ b/terraform/environments/cloudflare/main.tf
@@ -16,6 +16,8 @@ terraform {
     key                         = "cloudflare/terraform.tfstate"
     skip_credentials_validation = true
     skip_metadata_api_check     = true
+    skip_region_validation      = true
+    use_lockfile                = true
   }
 }
 

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -19,6 +19,8 @@ terraform {
     key                         = "dev/terraform.tfstate"
     skip_credentials_validation = true
     skip_metadata_api_check     = true
+    skip_region_validation      = true
+    use_lockfile                = true
   }
 }
 
@@ -29,6 +31,15 @@ provider "digitalocean" {
 provider "cloudflare" {
   api_token = var.cloudflare_api_token
 }
+
+# TODO: Migrate to stacks/wordpress module for environment parity with production.
+# Migration steps:
+# 1. Add module "wordpress" block (see production/main.tf for reference)
+# 2. Run: terraform state mv digitalocean_droplet.dev module.wordpress.digitalocean_droplet.this
+# 3. Run: terraform state mv digitalocean_firewall.dev module.wordpress.digitalocean_firewall.this
+# 4. Run: terraform plan — verify no destroy/create actions
+# 5. Remove inline resource definitions
+# Tracked in: https://github.com/pausatf/pausatf/issues
 
 # Dev Droplet (smaller)
 #tfsec:ignore:digitalocean-compute-use-ssh-keys

--- a/terraform/environments/github/main.tf
+++ b/terraform/environments/github/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.0"
+  required_version = ">= 1.10.0"
 
   required_providers {
     github = {
@@ -16,6 +16,7 @@ terraform {
     skip_credentials_validation = true
     skip_metadata_api_check     = true
     skip_region_validation      = true
+    use_lockfile                = true
   }
 }
 

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -20,6 +20,8 @@ terraform {
     key                         = "production/terraform.tfstate"
     skip_credentials_validation = true
     skip_metadata_api_check     = true
+    skip_region_validation      = true
+    use_lockfile                = true
   }
 }
 

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -20,6 +20,8 @@ terraform {
     key                         = "staging/terraform.tfstate"
     skip_credentials_validation = true
     skip_metadata_api_check     = true
+    skip_region_validation      = true
+    use_lockfile                = true
   }
 }
 
@@ -30,6 +32,15 @@ provider "digitalocean" {
 provider "cloudflare" {
   api_token = var.cloudflare_api_token
 }
+
+# TODO: Migrate to stacks/wordpress module for environment parity with production.
+# Migration steps:
+# 1. Add module "wordpress" block (see production/main.tf for reference)
+# 2. Run: terraform state mv digitalocean_droplet.staging module.wordpress.digitalocean_droplet.this
+# 3. Run: terraform state mv digitalocean_firewall.staging module.wordpress.digitalocean_firewall.this
+# 4. Run: terraform plan — verify no destroy/create actions
+# 5. Remove inline resource definitions
+# Tracked in: https://github.com/pausatf/pausatf/issues
 
 # Staging Droplet
 #tfsec:ignore:digitalocean-compute-use-ssh-keys


### PR DESCRIPTION
## Summary

Addresses all remaining high and medium architecture gaps from the deep audit.

**High priority:**
- **ARCH-1**: Extract production-specific variables from `all.yml` into `group_vars/production/main.yml` — prevents production values bleeding into dev/staging
- **ARCH-4**: Terraform state locking via `use_lockfile=true` (S3 native) + advisory file-based locking in wrapper script. Wrapper now supports all 5 environments.

**Medium priority:**
- **ARCH-3**: Document staging/dev terraform module migration path with `state mv` commands. Standardize all 5 backend configs.
- **ARCH-5**: Convert site.yml webservers play to block/rescue — logs failure details, verifies web server still running, then re-fails for visibility
- **ARCH-7**: Wire existing Molecule tests (common, wordpress) into ansible-lint CI workflow
- **ARCH-9**: Add wordpress_installs auth key assertion — catches vault vars defined but not wired through to template input

## Test plan

- [ ] `ansible-playbook --syntax-check ansible/site.yml` passes with block/rescue structure
- [ ] `terraform init` succeeds with `use_lockfile=true` on DO Spaces backend
- [ ] Production ansible run: group_vars merge produces same effective variables (production/main.yml + all.yml = previous all.yml)
- [ ] Wrapper script lock prevents concurrent runs for same environment
- [ ] Molecule job appears in CI workflow (may need Docker-in-Docker runner)
- [ ] WordPress assertion fires when auth_key is empty in wordpress_installs