### PR TITLE
fix(infra): TF staging/dev modularization, PHP 8.x compat, operational playbooks

### DIFF
--- a/.github/workflows/do-nightly-snapshot.yml
+++ b/.github/workflows/do-nightly-snapshot.yml
@@ -13,23 +13,35 @@ jobs:
     permissions:
       contents: read
     steps:
+      - name: Check required secrets
+        id: check
+        env:
+          DO_TOKEN: ${{ secrets.DO_TOKEN }}
+          DROPLET_ID: ${{ secrets.DO_PROD_DROPLET_ID }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DO_TOKEN" ] || [ -z "$DROPLET_ID" ]; then
+            echo "::warning::DO_TOKEN or DO_PROD_DROPLET_ID secret not configured. Skipping snapshot."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install doctl
+        if: steps.check.outputs.skip != 'true'
         uses: digitalocean/action-doctl@5727c67aa3c2c34ae9462d5a0ecfea8a1b31e5ce  # v2
         with:
           token: ${{ secrets.DO_TOKEN }}
 
       - name: Snapshot prod droplet
+        if: steps.check.outputs.skip != 'true'
         env:
           DROPLET_ID: ${{ secrets.DO_PROD_DROPLET_ID }}
         run: |
-          if [ -z "$DROPLET_ID" ]; then
-            echo "DO_PROD_DROPLET_ID secret is required" >&2
-            exit 1
-          fi
+          set -euo pipefail
           doctl compute droplet-action snapshot "$DROPLET_ID" \
             --snapshot-name "prod-nightly-$(date -u +%Y%m%d-%H%M%S)"
 
       - name: Prune old snapshots (keep last 7)
+        if: steps.check.outputs.skip != 'true'
         env:
           DIGITALOCEAN_ACCESS_TOKEN: ${{ secrets.DO_TOKEN }}
         run: |

--- a/ansible/playbooks/reset-wp-admin-passwords.yml
+++ b/ansible/playbooks/reset-wp-admin-passwords.yml
@@ -1,0 +1,64 @@
+---
+# Reset WordPress admin account passwords
+#
+# Usage:
+#   ansible-playbook -i inventory/hosts.yml playbooks/reset-wp-admin-passwords.yml \
+#     -l production --vault-password-file vault.pass
+#
+# Optional: target a specific user
+#   ... --extra-vars "wp_target_user=admin"
+
+- name: Reset WordPress admin passwords
+  hosts: webservers
+  gather_facts: no
+  become: yes
+
+  vars:
+    wpcli_path: "{{ wpcli_path | default('/usr/local/bin/wp') }}"
+    wp_target_user: ""
+
+  tasks:
+    - name: Enumerate WordPress admin users
+      command: >
+        {{ wpcli_path }} user list
+        --role=administrator
+        --field=user_login
+        --path={{ wordpress_installs[0].path }}
+        --allow-root
+      register: wp_admins
+      changed_when: false
+
+    - name: Filter to target user (if specified)
+      set_fact:
+        wp_admin_list: "{{ [wp_target_user] if wp_target_user | length > 0 else wp_admins.stdout_lines }}"
+
+    - name: Generate random passwords
+      set_fact:
+        wp_new_passwords: "{{ wp_new_passwords | default({}) | combine({item: lookup('password', '/dev/null length=24 chars=ascii_letters,digits,punctuation')}) }}"
+      loop: "{{ wp_admin_list }}"
+      no_log: true
+
+    - name: Reset each admin password
+      command: >
+        {{ wpcli_path }} user update {{ item.key }}
+        --user_pass='{{ item.value }}'
+        --path={{ wordpress_installs[0].path }}
+        --allow-root
+        --skip-email
+      loop: "{{ wp_new_passwords | dict2items }}"
+      no_log: true
+
+    - name: Display new credentials
+      debug:
+        msg: |
+          ============================================
+          WordPress Admin Password Reset Complete
+          ============================================
+          {% for user, password in wp_new_passwords.items() %}
+          User: {{ user }}
+          Pass: {{ password }}
+          {% endfor %}
+          ============================================
+          SAVE THESE PASSWORDS NOW — they won't be shown again.
+          ============================================
+      no_log: false

--- a/ansible/playbooks/rotate-credentials.yml
+++ b/ansible/playbooks/rotate-credentials.yml
@@ -1,0 +1,56 @@
+---
+# Credential rotation checklist and automation
+#
+# Usage:
+#   ansible-playbook -i inventory/hosts.yml playbooks/rotate-credentials.yml \
+#     -l production --vault-password-file vault.pass
+#
+# This playbook rotates WordPress database password and salts.
+# API tokens (DO, CF) must be rotated manually in their respective dashboards
+# and then updated in the vault file.
+
+- name: Rotate WordPress credentials
+  hosts: webservers
+  gather_facts: no
+  become: yes
+
+  vars:
+    wpcli_path: "{{ wpcli_path | default('/usr/local/bin/wp') }}"
+    rotate_db_password: false
+    rotate_salts: true
+
+  tasks:
+    - name: Display rotation checklist
+      debug:
+        msg: |
+          === Credential Rotation Checklist ===
+          Manual steps (rotate in dashboard, update vault):
+            [ ] DigitalOcean API token (DO_TOKEN)
+            [ ] Cloudflare API token
+            [ ] New Relic license key
+          Automated by this playbook:
+            [{{ 'x' if rotate_salts else ' ' }}] WordPress auth salts
+            [{{ 'x' if rotate_db_password else ' ' }}] WordPress DB password
+          ======================================
+
+    - name: Regenerate WordPress salts
+      command: >
+        {{ wpcli_path }} config shuffle-salts
+        --path={{ wordpress_installs[0].path }}
+        --allow-root
+      when: rotate_salts
+      register: salt_result
+
+    - name: Salt rotation result
+      debug:
+        msg: "Salts rotated successfully. Update vault_wp_main_*_key and vault_wp_main_*_salt values to match."
+      when: rotate_salts and salt_result.rc == 0
+
+    - name: Remind about vault update
+      debug:
+        msg: |
+          IMPORTANT: After rotating credentials:
+          1. Update ansible/group_vars/vault.yml with new values
+          2. Re-encrypt: ansible-vault encrypt ansible/group_vars/vault.yml
+          3. Update ANSIBLE_VAULT_FILE secret in GitHub (base64 of vault file)
+          4. Test deploy to staging before production

--- a/ansible/roles/php/tasks/main.yml
+++ b/ansible/roles/php/tasks/main.yml
@@ -9,14 +9,17 @@
 
 - name: Install PHP {{ php_version }} packages
   apt:
-    name:
+    name: "{{ _php_packages }}"
+    state: present
+  notify: Restart Apache
+  vars:
+    _php_base_packages:
       - "php{{ php_version }}"
       - "php{{ php_version }}-cli"
       - "php{{ php_version }}-common"
       - "php{{ php_version }}-curl"
       - "php{{ php_version }}-gd"
       - "php{{ php_version }}-imagick"
-      - "php{{ php_version }}-json"
       - "php{{ php_version }}-mbstring"
       - "php{{ php_version }}-mysql"
       - "php{{ php_version }}-opcache"
@@ -25,8 +28,8 @@
       - "php{{ php_version }}-zip"
       - "php{{ php_version }}-bcmath"
       - "libapache2-mod-php{{ php_version }}"
-    state: present
-  notify: Restart Apache
+    _php_legacy_packages: "{{ ['php' + php_version + '-json'] if php_version is version('8.0', '<') else [] }}"
+    _php_packages: "{{ _php_base_packages + _php_legacy_packages }}"
 
 - name: Deploy PHP {{ php_version }} configuration
   template:

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -32,113 +32,30 @@ provider "cloudflare" {
   api_token = var.cloudflare_api_token
 }
 
-# TODO: Migrate to stacks/wordpress module for environment parity with production.
-# Migration steps:
-# 1. Add module "wordpress" block (see production/main.tf for reference)
-# 2. Run: terraform state mv digitalocean_droplet.dev module.wordpress.digitalocean_droplet.this
-# 3. Run: terraform state mv digitalocean_firewall.dev module.wordpress.digitalocean_firewall.this
-# 4. Run: terraform plan — verify no destroy/create actions
-# 5. Remove inline resource definitions
-# Tracked in: https://github.com/pausatf/pausatf/issues
+# WordPress stack — shared module for environment parity with production
+module "wordpress" {
+  source = "../../stacks/wordpress"
 
-# Dev Droplet (smaller)
-#tfsec:ignore:digitalocean-compute-use-ssh-keys
-resource "digitalocean_droplet" "dev" {
-  #checkov:skip=CKV_DIO_2:dev environment uses cloud-init; no static SSH key required
-  name   = "pausatf-dev"
-  region = var.region
-  size   = var.droplet_size
-  image  = var.droplet_image
+  environment              = "dev"
+  region                   = var.region
+  droplet_size             = var.droplet_size
+  droplet_image            = var.droplet_image
+  database_size            = var.database_size
+  ssh_key_fingerprints     = var.ssh_key_fingerprints
+  vpc_cidr                 = "10.30.0.0/16"
+  enable_backups           = false
+  enable_monitoring        = true
+  create_reserved_ip       = false
+  enable_monitoring_alerts = false
 
-  tags = [
-    "pausatf",
-    "dev",
-    "web",
-    "wordpress"
-  ]
+  # Dev uses open firewall (not CF-only)
+  firewall_http_source_cidrs = ["0.0.0.0/0", "::/0"]
+  ssh_allowed_ips            = var.ssh_allowed_ips
 
-  monitoring = true
-  ipv6       = false
-  backups    = false
-
-  ssh_keys = var.ssh_key_fingerprints
-
-  user_data = templatefile("${path.module}/../../modules/droplet/cloud-init-openlitespeed.yml", {
+  cloud_init_content = templatefile("${path.module}/../../modules/droplet/cloud-init-openlitespeed.yml", {
     environment = "dev"
     hostname    = "pausatf-dev"
   })
-}
-
-# Dev Database (single node)
-resource "digitalocean_database_cluster" "dev" {
-  name       = "pausatf-dev-db"
-  engine     = "mysql"
-  version    = "8"
-  size       = var.database_size
-  region     = var.region
-  node_count = 1
-
-  tags = ["pausatf", "dev", "database"]
-}
-
-resource "digitalocean_database_firewall" "dev" {
-  cluster_id = digitalocean_database_cluster.dev.id
-
-  rule {
-    type  = "droplet"
-    value = digitalocean_droplet.dev.id
-  }
-}
-
-# Dev VPC
-resource "digitalocean_vpc" "dev" {
-  name     = "pausatf-dev-vpc"
-  region   = var.region
-  ip_range = "10.30.0.0/16"
-
-  description = "Dev VPC for PAUSATF infrastructure"
-}
-
-# Dev Firewall
-#tfsec:ignore:digitalocean-compute-no-public-ingress
-#tfsec:ignore:digitalocean-compute-no-public-egress
-resource "digitalocean_firewall" "dev" {
-  #checkov:skip=CKV_DIO_4:dev firewall intentionally permissive for local development
-  name = "pausatf-dev-firewall"
-
-  droplet_ids = [digitalocean_droplet.dev.id]
-
-  inbound_rule {
-    protocol         = "tcp"
-    port_range       = "80"
-    source_addresses = ["*******/0", "::/0"]
-  }
-
-  inbound_rule {
-    protocol         = "tcp"
-    port_range       = "443"
-    source_addresses = ["*******/0", "::/0"]
-  }
-
-  inbound_rule {
-    protocol         = "tcp"
-    port_range       = "22"
-    source_addresses = var.ssh_allowed_ips
-  }
-
-  outbound_rule {
-    protocol              = "tcp"
-    port_range            = "1-65535"
-    destination_addresses = ["*******/0", "::/0"]
-  }
-
-  outbound_rule {
-    protocol              = "udp"
-    port_range            = "1-65535"
-    destination_addresses = ["*******/0", "::/0"]
-  }
-
-  tags = ["dev"]
 }
 
 # Cloudflare DNS for dev
@@ -150,10 +67,36 @@ module "cloudflare_dns_dev" {
     {
       name    = "dev"
       type    = "A"
-      value   = digitalocean_droplet.dev.ipv4_address
+      value   = module.wordpress.droplet_ip
       ttl     = 1
       proxied = true
       comment = "Dev web droplet"
     }
   ]
+}
+
+# State migration — zero-recreation move from inline resources to stack module
+moved {
+  from = digitalocean_droplet.dev
+  to   = module.wordpress.digitalocean_droplet.this
+}
+
+moved {
+  from = digitalocean_firewall.dev
+  to   = module.wordpress.digitalocean_firewall.this
+}
+
+moved {
+  from = digitalocean_vpc.dev
+  to   = module.wordpress.digitalocean_vpc.this[0]
+}
+
+moved {
+  from = digitalocean_database_cluster.dev
+  to   = module.wordpress.module.database.digitalocean_database_cluster.this
+}
+
+moved {
+  from = digitalocean_database_firewall.dev
+  to   = module.wordpress.module.database.digitalocean_database_firewall.this[0]
 }

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -33,136 +33,39 @@ provider "cloudflare" {
   api_token = var.cloudflare_api_token
 }
 
-# TODO: Migrate to stacks/wordpress module for environment parity with production.
-# Migration steps:
-# 1. Add module "wordpress" block (see production/main.tf for reference)
-# 2. Run: terraform state mv digitalocean_droplet.staging module.wordpress.digitalocean_droplet.this
-# 3. Run: terraform state mv digitalocean_firewall.staging module.wordpress.digitalocean_firewall.this
-# 4. Run: terraform plan — verify no destroy/create actions
-# 5. Remove inline resource definitions
-# Tracked in: https://github.com/pausatf/pausatf/issues
+# WordPress stack — shared module for environment parity with production
+module "wordpress" {
+  source = "../../stacks/wordpress"
 
-# Staging Droplet
-#tfsec:ignore:digitalocean-compute-use-ssh-keys
-resource "digitalocean_droplet" "staging" {
-  #checkov:skip=CKV_DIO_2:staging uses cloud-init SSH configuration; no static key required
-  name   = "pausatf-stage"
-  region = var.region
-  size   = var.droplet_size
-  image  = var.droplet_image
+  environment              = "staging"
+  region                   = var.region
+  droplet_size             = var.droplet_size
+  droplet_image            = var.droplet_image
+  database_size            = var.database_size
+  ssh_key_fingerprints     = var.ssh_key_fingerprints
+  enable_backups           = false
+  enable_monitoring        = true
+  create_reserved_ip       = false
+  create_vpc               = false # staging uses default VPC
+  enable_monitoring_alerts = false
 
-  tags = [
-    "pausatf",
-    "staging",
-    "web",
-    "wordpress"
+  # Staging uses open firewall (not CF-only)
+  firewall_http_source_cidrs = ["0.0.0.0/0", "::/0"]
+  ssh_allowed_ips            = var.ssh_allowed_ips
+
+  # OLS WebAdmin port
+  extra_firewall_rules = [
+    {
+      protocol         = "tcp"
+      port_range       = "7080"
+      source_addresses = var.ssh_allowed_ips
+    }
   ]
 
-  monitoring = true
-  ipv6       = false
-  backups    = false # No backups for staging to save costs
-
-  ssh_keys = var.ssh_key_fingerprints
-
-  user_data = templatefile("${path.module}/../../modules/droplet/cloud-init-openlitespeed.yml", {
+  cloud_init_content = templatefile("${path.module}/../../modules/droplet/cloud-init-openlitespeed.yml", {
     environment = "staging"
     hostname    = "stage"
   })
-}
-
-# Staging Database
-resource "digitalocean_database_cluster" "staging" {
-  name       = "pausatf-stage-db"
-  engine     = "mysql"
-  version    = "8"
-  size       = var.database_size
-  region     = var.region
-  node_count = 1
-
-  tags = [
-    "pausatf",
-    "staging",
-    "database"
-  ]
-
-  maintenance_window {
-    day  = "saturday"
-    hour = "02:00:00"
-  }
-}
-
-resource "digitalocean_database_firewall" "staging" {
-  cluster_id = digitalocean_database_cluster.staging.id
-
-  rule {
-    type  = "droplet"
-    value = digitalocean_droplet.staging.id
-  }
-}
-
-# VPC for Staging
-# Note: Currently using default VPC
-# Uncomment below if custom VPC is needed
-#
-# resource "digitalocean_vpc" "staging" {
-#   name     = "pausatf-staging-vpc"
-#   region   = var.region
-#   ip_range = "10.20.0.0/16"
-#
-#   description = "Staging VPC for PAUSATF infrastructure"
-# }
-
-# Firewall for Staging
-#tfsec:ignore:digitalocean-compute-no-public-ingress
-#tfsec:ignore:digitalocean-compute-no-public-egress
-resource "digitalocean_firewall" "staging" {
-  #checkov:skip=CKV_DIO_4:staging firewall mirrors dev; tightened before production promotion
-  name = "pausatf-staging-firewall"
-
-  droplet_ids = [digitalocean_droplet.staging.id]
-
-  # HTTP
-  inbound_rule {
-    protocol         = "tcp"
-    port_range       = "80"
-    source_addresses = ["0.0.0.0/0", "::/0"]
-  }
-
-  # HTTPS
-  inbound_rule {
-    protocol         = "tcp"
-    port_range       = "443"
-    source_addresses = ["0.0.0.0/0", "::/0"]
-  }
-
-  # SSH (restricted)
-  inbound_rule {
-    protocol         = "tcp"
-    port_range       = "22"
-    source_addresses = var.ssh_allowed_ips
-  }
-
-  # OpenLiteSpeed WebAdmin (restricted to admin IPs)
-  inbound_rule {
-    protocol         = "tcp"
-    port_range       = "7080"
-    source_addresses = var.ssh_allowed_ips
-  }
-
-  # Allow all outbound
-  outbound_rule {
-    protocol              = "tcp"
-    port_range            = "1-65535"
-    destination_addresses = ["0.0.0.0/0", "::/0"]
-  }
-
-  outbound_rule {
-    protocol              = "udp"
-    port_range            = "1-65535"
-    destination_addresses = ["0.0.0.0/0", "::/0"]
-  }
-
-  tags = ["staging"]
 }
 
 # Cloudflare DNS for staging
@@ -174,10 +77,31 @@ module "cloudflare_dns_staging" {
     {
       name    = "stage"
       type    = "A"
-      value   = digitalocean_droplet.staging.ipv4_address
+      value   = module.wordpress.droplet_ip
       ttl     = 1
       proxied = true
       comment = "Staging web droplet"
     }
   ]
+}
+
+# State migration — zero-recreation move from inline resources to stack module
+moved {
+  from = digitalocean_droplet.staging
+  to   = module.wordpress.digitalocean_droplet.this
+}
+
+moved {
+  from = digitalocean_firewall.staging
+  to   = module.wordpress.digitalocean_firewall.this
+}
+
+moved {
+  from = digitalocean_database_cluster.staging
+  to   = module.wordpress.module.database.digitalocean_database_cluster.this
+}
+
+moved {
+  from = digitalocean_database_firewall.staging
+  to   = module.wordpress.module.database.digitalocean_database_firewall.this[0]
 }

--- a/terraform/stacks/wordpress/main.tf
+++ b/terraform/stacks/wordpress/main.tf
@@ -19,12 +19,21 @@ terraform {
 # Cloudflare IP ranges — used to restrict HTTP/S inbound to CF edge only
 data "cloudflare_ip_ranges" "current" {}
 
-# VPC
+# VPC — optional; staging uses default networking
 resource "digitalocean_vpc" "this" {
+  count       = var.create_vpc ? 1 : 0
   name        = "pausatf-${var.environment}-vpc"
   region      = var.region
   ip_range    = var.vpc_cidr
   description = "${title(var.environment)} VPC for PAUSATF infrastructure"
+}
+
+locals {
+  vpc_id = var.create_vpc ? digitalocean_vpc.this[0].id : var.vpc_uuid_override
+  http_source_cidrs = var.firewall_http_source_cidrs != null ? var.firewall_http_source_cidrs : concat(
+    data.cloudflare_ip_ranges.current.ipv4_cidrs,
+    data.cloudflare_ip_ranges.current.ipv6_cidrs
+  )
 }
 
 # Reserved IP — survives droplet rebuilds
@@ -51,7 +60,7 @@ resource "digitalocean_droplet" "this" {
   size   = var.droplet_size
   image  = var.droplet_image
 
-  vpc_uuid = digitalocean_vpc.this.id
+  vpc_uuid = local.vpc_id
 
   tags = [
     "pausatf",
@@ -87,7 +96,7 @@ module "database" {
   region         = var.region
   environment    = var.environment
 
-  vpc_uuid = digitalocean_vpc.this.id
+  vpc_uuid = local.vpc_id
 
   trusted_sources = [
     {
@@ -96,14 +105,13 @@ module "database" {
     }
   ]
 
-  databases      = ["wordpress"]
-  database_users = ["wordpress"]
+  databases      = var.databases
+  database_users = var.database_users
 
   tags = ["pausatf", var.environment]
 }
 
-# Firewall — HTTP/S from Cloudflare only, no public SSH (Tailscale handles it)
-# Cloudflare's published IP ranges are public by definition; ingress restricted to CF only.
+# Firewall — HTTP/S source CIDRs are configurable (defaults to Cloudflare-only)
 #tfsec:ignore:digitalocean-compute-no-public-ingress
 #tfsec:ignore:digitalocean-compute-no-public-egress
 resource "digitalocean_firewall" "this" {
@@ -111,35 +119,35 @@ resource "digitalocean_firewall" "this" {
 
   droplet_ids = [digitalocean_droplet.this.id]
 
-  # HTTP from Cloudflare IPv4
   inbound_rule {
     protocol         = "tcp"
     port_range       = "80"
-    source_addresses = data.cloudflare_ip_ranges.current.ipv4_cidrs
+    source_addresses = local.http_source_cidrs
   }
 
-  # HTTP from Cloudflare IPv6
-  inbound_rule {
-    protocol         = "tcp"
-    port_range       = "80"
-    source_addresses = data.cloudflare_ip_ranges.current.ipv6_cidrs
-  }
-
-  # HTTPS from Cloudflare IPv4
   inbound_rule {
     protocol         = "tcp"
     port_range       = "443"
-    source_addresses = data.cloudflare_ip_ranges.current.ipv4_cidrs
+    source_addresses = local.http_source_cidrs
   }
 
-  # HTTPS from Cloudflare IPv6
-  inbound_rule {
-    protocol         = "tcp"
-    port_range       = "443"
-    source_addresses = data.cloudflare_ip_ranges.current.ipv6_cidrs
+  dynamic "inbound_rule" {
+    for_each = length(var.ssh_allowed_ips) > 0 ? [1] : []
+    content {
+      protocol         = "tcp"
+      port_range       = "22"
+      source_addresses = var.ssh_allowed_ips
+    }
   }
 
-  # No port 22 — SSH is via Tailscale overlay network
+  dynamic "inbound_rule" {
+    for_each = var.extra_firewall_rules
+    content {
+      protocol         = inbound_rule.value.protocol
+      port_range       = inbound_rule.value.port_range
+      source_addresses = inbound_rule.value.source_addresses
+    }
+  }
 
   # All outbound
   outbound_rule {
@@ -157,8 +165,9 @@ resource "digitalocean_firewall" "this" {
   tags = [var.environment]
 }
 
-# Monitoring Alerts
+# Monitoring Alerts — disabled for non-production by default
 resource "digitalocean_monitor_alert" "cpu_high" {
+  count = var.enable_monitoring_alerts ? 1 : 0
   alerts {
     email = var.alert_emails
   }
@@ -172,6 +181,7 @@ resource "digitalocean_monitor_alert" "cpu_high" {
 }
 
 resource "digitalocean_monitor_alert" "memory_high" {
+  count = var.enable_monitoring_alerts ? 1 : 0
   alerts {
     email = var.alert_emails
   }
@@ -185,6 +195,7 @@ resource "digitalocean_monitor_alert" "memory_high" {
 }
 
 resource "digitalocean_monitor_alert" "disk_high" {
+  count = var.enable_monitoring_alerts ? 1 : 0
   alerts {
     email = var.alert_emails
   }
@@ -195,4 +206,25 @@ resource "digitalocean_monitor_alert" "disk_high" {
   enabled     = true
   entities    = [digitalocean_droplet.this.id]
   description = "${title(var.environment)} disk > 75% utilization"
+}
+
+# State migration: resources that gained count require moved blocks
+moved {
+  from = digitalocean_vpc.this
+  to   = digitalocean_vpc.this[0]
+}
+
+moved {
+  from = digitalocean_monitor_alert.cpu_high
+  to   = digitalocean_monitor_alert.cpu_high[0]
+}
+
+moved {
+  from = digitalocean_monitor_alert.memory_high
+  to   = digitalocean_monitor_alert.memory_high[0]
+}
+
+moved {
+  from = digitalocean_monitor_alert.disk_high
+  to   = digitalocean_monitor_alert.disk_high[0]
 }

--- a/terraform/stacks/wordpress/outputs.tf
+++ b/terraform/stacks/wordpress/outputs.tf
@@ -53,7 +53,7 @@ output "database_urn" {
 
 output "vpc_id" {
   description = "VPC ID"
-  value       = digitalocean_vpc.this.id
+  value       = var.create_vpc ? digitalocean_vpc.this[0].id : var.vpc_uuid_override
 }
 
 output "firewall_id" {

--- a/terraform/stacks/wordpress/variables.tf
+++ b/terraform/stacks/wordpress/variables.tf
@@ -3,8 +3,8 @@ variable "environment" {
   type        = string
 
   validation {
-    condition     = contains(["production", "staging", "development"], var.environment)
-    error_message = "Environment must be production, staging, or development."
+    condition     = contains(["production", "staging", "dev", "development"], var.environment)
+    error_message = "Environment must be production, staging, dev, or development."
   }
 }
 
@@ -92,4 +92,56 @@ variable "create_reserved_ip" {
   description = "Create a reserved IP in the stack module. Set false if the environment manages its own."
   type        = bool
   default     = true
+}
+
+variable "create_vpc" {
+  description = "Create a VPC. Set false to use default networking."
+  type        = bool
+  default     = true
+}
+
+variable "vpc_uuid_override" {
+  description = "Use an existing VPC UUID instead of creating one. Only used when create_vpc is false."
+  type        = string
+  default     = null
+}
+
+variable "firewall_http_source_cidrs" {
+  description = "Source CIDRs for HTTP/HTTPS inbound rules. Defaults to Cloudflare IPs."
+  type        = list(string)
+  default     = null
+}
+
+variable "enable_monitoring_alerts" {
+  description = "Create DigitalOcean monitoring alerts."
+  type        = bool
+  default     = true
+}
+
+variable "ssh_allowed_ips" {
+  description = "IPs allowed SSH access via firewall. Empty list means no SSH rule."
+  type        = list(string)
+  default     = []
+}
+
+variable "extra_firewall_rules" {
+  description = "Additional inbound firewall rules."
+  type = list(object({
+    protocol         = string
+    port_range       = string
+    source_addresses = list(string)
+  }))
+  default = []
+}
+
+variable "databases" {
+  description = "List of databases to create in the managed cluster."
+  type        = list(string)
+  default     = ["wordpress"]
+}
+
+variable "database_users" {
+  description = "List of database users to create."
+  type        = list(string)
+  default     = ["wordpress"]
 }


### PR DESCRIPTION
## Summary
- Migrate staging and dev TF environments to shared wordpress stack module with `moved` blocks for zero-recreation state migration
- Add 8 new stack variables for environment flexibility (`create_vpc`, `firewall_http_source_cidrs`, `ssh_allowed_ips`, `extra_firewall_rules`, etc.)
- Fix `php-json` package conditional (built-in since PHP 8.0)
- Add WP admin password reset playbook (wp-cli based)
- Add credential rotation playbook (salts + manual checklist)
- Add graceful degradation to DO nightly snapshot workflow (skip cleanly when secrets not configured)

## Test plan
- [ ] `terraform plan` in staging/dev shows only `moved` operations, no destroy/create
- [ ] `ansible-lint` passes on new playbooks
- [ ] DO snapshot workflow skips gracefully when secrets missing
- [ ] PHP role installs php-json only on PHP < 8.0