### PR TITLE
fix(infra): resolve 12 logic bugs and architecture gaps (round 7)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,7 +11,7 @@ jobs:
     uses: ./.github/workflows/deploy.yml
     with:
       environment: development
-      ansible_limit: development
+      ansible_limit: dev
     secrets:
       SSH_PRIVATE_KEY: ${{ secrets.DEV_SSH_PRIVATE_KEY }}
       ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -12,5 +12,6 @@ jobs:
       environment: staging
       ansible_limit: staging
     secrets:
+      SSH_PRIVATE_KEY: ${{ secrets.STAGING_SSH_PRIVATE_KEY }}
       ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
       ANSIBLE_VAULT_FILE: ${{ secrets.ANSIBLE_VAULT_FILE }}

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -120,7 +120,7 @@ apache_modules:
 # =============================================================================
 php_version: "8.3"
 use_php_fpm: true
-php_fpm_socket: "/run/php/php8.3-fpm.sock"
+php_fpm_socket: "/run/php/php{{ php_version }}-fpm.sock"
 
 # PHP settings (for WordPress optimization)
 php_memory_limit: "256M"
@@ -162,6 +162,7 @@ php_opcache_save_comments: 1
 # Only mysql-client is installed for wp-cli and maintenance tasks.
 mysql_version: "8"
 mysql_managed: true
+mysql_enabled: false
 mysql_port: 25060  # DO Managed MySQL default port
 
 # =============================================================================

--- a/ansible/group_vars/dev.yml
+++ b/ansible/group_vars/dev.yml
@@ -21,3 +21,11 @@ wordpress_installs:
     disallow_file_mods: false
     auto_update_core: "minor"
     fs_method: "direct"
+    auth_key: "{{ vault_wp_dev_auth_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+    secure_auth_key: "{{ vault_wp_dev_secure_auth_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+    logged_in_key: "{{ vault_wp_dev_logged_in_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+    nonce_key: "{{ vault_wp_dev_nonce_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+    auth_salt: "{{ vault_wp_dev_auth_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+    secure_auth_salt: "{{ vault_wp_dev_secure_auth_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+    logged_in_salt: "{{ vault_wp_dev_logged_in_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+    nonce_salt: "{{ vault_wp_dev_nonce_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"

--- a/ansible/group_vars/staging.yml
+++ b/ansible/group_vars/staging.yml
@@ -22,3 +22,11 @@ wordpress_installs:
     disallow_file_mods: false
     auto_update_core: "minor"
     fs_method: "direct"
+    auth_key: "{{ vault_wp_stage_auth_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+    secure_auth_key: "{{ vault_wp_stage_secure_auth_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+    logged_in_key: "{{ vault_wp_stage_logged_in_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+    nonce_key: "{{ vault_wp_stage_nonce_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+    auth_salt: "{{ vault_wp_stage_auth_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+    secure_auth_salt: "{{ vault_wp_stage_secure_auth_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+    logged_in_salt: "{{ vault_wp_stage_logged_in_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+    nonce_salt: "{{ vault_wp_stage_nonce_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"

--- a/ansible/inventory/hosts.yml
+++ b/ansible/inventory/hosts.yml
@@ -19,7 +19,6 @@ all:
           wordpress_path: /var/www/html
           legacy_path: /var/www/legacy/public_html
           web_server: apache
-          php_version: "7.4"
           wordpress_enabled: true
 
     # Staging Environment
@@ -31,7 +30,6 @@ all:
           ansible_python_interpreter: /usr/bin/python3
           wordpress_path: /var/www/html
           web_server: openlitespeed
-          php_version: "8.3"
           wordpress_enabled: true
 
     # Development Environment
@@ -43,7 +41,6 @@ all:
           ansible_python_interpreter: /usr/bin/python3
           wordpress_path: /var/www/html
           web_server: openlitespeed
-          php_version: "8.4"
           wordpress_enabled: true
 
     # WordPress Servers umbrella

--- a/ansible/playbooks/restore-prod.yml
+++ b/ansible/playbooks/restore-prod.yml
@@ -117,7 +117,7 @@
       mysql_user:
         name: "{{ db_creds.results[1].stdout }}"
         password: "{{ db_creds.results[2].stdout }}"
-        priv: "{{ db_creds.results[0].stdout }}.*:ALL"
+        priv: "{{ db_creds.results[0].stdout }}.*:SELECT,INSERT,UPDATE,DELETE,CREATE,DROP,INDEX,ALTER,CREATE TEMPORARY TABLES"
         state: present
         login_user: root
       no_log: true

--- a/ansible/roles/certbot/tasks/main.yml
+++ b/ansible/roles/certbot/tasks/main.yml
@@ -49,12 +49,12 @@
     state: started
     enabled: yes
 
-- name: Deploy post-renewal hook to reload Apache
+- name: Deploy post-renewal hook to reload web server
   copy:
-    dest: /etc/letsencrypt/renewal-hooks/deploy/reload-apache.sh
+    dest: /etc/letsencrypt/renewal-hooks/deploy/reload-webserver.sh
     content: |
       #!/bin/bash
-      systemctl reload apache2
+      systemctl reload {{ 'apache2' if web_server | default('apache') == 'apache' else 'lsws' }}
     owner: root
     group: root
     mode: '0755'

--- a/ansible/roles/monitoring/templates/backup-wordpress.sh.j2
+++ b/ansible/roles/monitoring/templates/backup-wordpress.sh.j2
@@ -24,11 +24,14 @@ trap 'rm -f /root/.my-backup-*.cnf' EXIT
 # Backup {{ wp.name }}
 log "Backing up {{ wp.name }}..."
 
+# NOTE: DB credentials are rendered into this script by Ansible. The script
+# is deployed with mode 0750 (root only). For stronger isolation, deploy a
+# separate /root/.my-backup.cnf managed by Ansible instead.
 # Database backup — credentials via temp file to avoid MYSQL_PWD env exposure
 _MYCNF=$(mktemp /root/.my-backup-XXXXXX.cnf)
 chmod 600 "$_MYCNF"
 printf '[client]\nuser=%s\npassword=%s\n' '{{ wp.db_user }}' '{{ wp.db_password }}' > "$_MYCNF"
-mysqldump --defaults-extra-file="$_MYCNF" {{ wp.db_name }} | gzip > "$BACKUP_DIR/{{ wp.name }}-db-$DATE.sql.gz"
+mysqldump --defaults-extra-file="$_MYCNF" --host='{{ wp.db_host | default("localhost") }}' {{ wp.db_name }} | gzip > "$BACKUP_DIR/{{ wp.name }}-db-$DATE.sql.gz"
 
 # Files backup
 tar -czf "$BACKUP_DIR/{{ wp.name }}-files-$DATE.tar.gz" -C "$(dirname '{{ wp.path }}')" "$(basename '{{ wp.path }}')" --exclude="wp-content/cache" --exclude="wp-content/uploads/cache"

--- a/ansible/roles/monitoring/templates/health-check.php.j2
+++ b/ansible/roles/monitoring/templates/health-check.php.j2
@@ -52,10 +52,10 @@ $checks['php'] = [
 
 // Check 2: MySQL connection
 try {
-    $db_host = '{{ wp_main_db_host | default("localhost") }}';
-    $db_name = '{{ wp_main_db_name | default("wordpress") }}';
-    $db_user = '{{ wp_main_db_user | default("wordpress") }}';
-    $db_pass = '{{ vault_wp_main_db_password | default("") }}';
+    $db_host = '{{ wordpress_installs[0].db_host | default("localhost") }}';
+    $db_name = '{{ wordpress_installs[0].db_name | default("wordpress") }}';
+    $db_user = '{{ wordpress_installs[0].db_user | default("wordpress") }}';
+    $db_pass = '{{ wordpress_installs[0].db_password | default("") }}';
 
     $pdo = new PDO(
         "mysql:host=$db_host;dbname=$db_name;charset=utf8mb4",
@@ -77,7 +77,7 @@ try {
 }
 
 // Check 3: WordPress files exist
-$wp_path = '{{ wp_main_document_root | default("/var/www/html") }}';
+$wp_path = '{{ wordpress_installs[0].path | default("/var/www/html") }}';
 $wp_files = ['wp-config.php', 'wp-includes/version.php', 'index.php'];
 $wp_healthy = true;
 

--- a/ansible/roles/newrelic/tasks/main.yml
+++ b/ansible/roles/newrelic/tasks/main.yml
@@ -1,14 +1,21 @@
 ---
 # New Relic role - Application monitoring for PAUSATF
 
-- name: Add New Relic repository key
-  apt_key:
+- name: Create keyrings directory
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
+
+- name: Download New Relic repository key
+  get_url:
     url: https://download.newrelic.com/infrastructure_agent/gpg/newrelic-infra.gpg
-    state: present
+    dest: /etc/apt/keyrings/newrelic-infra.gpg
+    mode: '0644'
 
 - name: Add New Relic repository
   apt_repository:
-    repo: "deb [arch=amd64] https://download.newrelic.com/infrastructure_agent/linux/apt {{ ansible_distribution_release }} main"
+    repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/newrelic-infra.gpg] https://download.newrelic.com/infrastructure_agent/linux/apt {{ ansible_distribution_release }} main"
     state: present
     filename: newrelic-infra
 

--- a/ansible/roles/wordpress/handlers/main.yml
+++ b/ansible/roles/wordpress/handlers/main.yml
@@ -1,15 +1,16 @@
 ---
-- name: restart nginx
+- name: Restart web server
   systemd:
-    name: nginx
+    name: "{{ 'apache2' if web_server | default('apache') == 'apache' else 'lsws' }}"
     state: restarted
 
-- name: restart php-fpm
+- name: Reload web server
   systemd:
-    name: php8.3-fpm
-    state: restarted
-
-- name: reload nginx
-  systemd:
-    name: nginx
+    name: "{{ 'apache2' if web_server | default('apache') == 'apache' else 'lsws' }}"
     state: reloaded
+
+- name: Restart PHP-FPM
+  systemd:
+    name: "php{{ php_version }}-fpm"
+    state: restarted
+  when: use_php_fpm | default(false)


### PR DESCRIPTION
## Summary
- **BLOCKER fixed**: Remove php_version from inventory host_vars — group_vars is now single source of truth (production was pinned to PHP 7.4 via host_var, overriding the 8.3 in group_vars)
- **MAJOR fixed**: Derive php_fpm_socket dynamically from php_version
- **MAJOR fixed**: Health-check template now references wordpress_installs[0] instead of undefined flat variables
- **MAJOR fixed**: Replace vestigial nginx handlers with web_server-conditional handlers
- **MAJOR fixed**: Add SSH key to staging deploy workflow; fix dev deploy ansible_limit to match inventory group name
- **MINOR fixed**: Scope restore playbook DB privileges to WordPress minimum set
- **MINOR fixed**: Add --host flag to backup mysqldump for remote DB support
- **MINOR fixed**: Add auth keys/salts to staging/dev wordpress_installs (were rendering empty)
- **MINOR fixed**: Template certbot renewal hook for web_server type
- **NITPICK fixed**: Replace deprecated apt_key with signed-by keyrings for New Relic
- **NITPICK fixed**: Set mysql_enabled: false (managed MySQL makes role unnecessary)

## Not addressed (separate scope)
- Finding 6: Rebuild playbook duplication (one-shot migration aid, separate cleanup PR)
- Finding 14: Restore playbook bare PHP packages (legacy emergency procedure)

## Test plan
- [ ] `ansible-lint` passes
- [ ] `terraform validate` passes (no TF changes)
- [ ] Verify staging/dev deploy workflows have SSH secrets configured in GitHub
- [ ] Health check renders correct DB credentials from wordpress_installs[0]