### PR TITLE
fix(infra): resolve 17 logic bugs, architecture gaps, and DRY issues (round 8)

### DIFF
--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -90,7 +90,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4
 
       - name: Setup TFLint
-        uses: terraform-linters/setup-tflint@v6
+        uses: terraform-linters/setup-tflint@4cb9feea73331a35b422df102992a03a44a3bb33  # v6
         with:
           tflint_version: latest
 

--- a/ansible/group_vars/dev.yml
+++ b/ansible/group_vars/dev.yml
@@ -2,7 +2,7 @@
 # Dev environment overrides
 web_server: openlitespeed
 php_version: "8.4"
-mysql_version: "8.0"
+mysql_version: "8"
 
 wordpress_installs:
   - name: "pausatf-main"

--- a/ansible/group_vars/production/main.yml
+++ b/ansible/group_vars/production/main.yml
@@ -62,6 +62,7 @@ cloudflare_dns_records:
 # SYSTEM — PRODUCTION HOSTNAME
 # =============================================================================
 hostname: "pausatf-prod"
+web_server: apache
 
 # =============================================================================
 # WORDPRESS — PRODUCTION INSTALL

--- a/ansible/group_vars/staging.yml
+++ b/ansible/group_vars/staging.yml
@@ -2,7 +2,7 @@
 # Staging environment overrides
 web_server: openlitespeed
 php_version: "8.4"
-mysql_version: "8.0"
+mysql_version: "8"
 
 # WordPress core on staging follows latest minor
 wordpress_installs:

--- a/ansible/playbooks/rebuild-ubuntu2404.yml
+++ b/ansible/playbooks/rebuild-ubuntu2404.yml
@@ -92,7 +92,7 @@
         enabled: yes
       loop:
         - apache2
-        - php8.3-fpm
+        - "php{{ php_version }}-fpm"
         - redis-server
         - fail2ban
         - tailscaled

--- a/ansible/playbooks/restore-prod.yml
+++ b/ansible/playbooks/restore-prod.yml
@@ -39,17 +39,16 @@
       apt:
         name:
           - apache2
-          - mysql-server
-          - php
-          - php-mysql
-          - php-cli
-          - php-curl
-          - php-gd
-          - php-mbstring
-          - php-xml
-          - php-xmlrpc
-          - php-zip
+          - "php{{ php_version }}"
+          - "php{{ php_version }}-mysql"
+          - "php{{ php_version }}-cli"
+          - "php{{ php_version }}-curl"
+          - "php{{ php_version }}-gd"
+          - "php{{ php_version }}-mbstring"
+          - "php{{ php_version }}-xml"
+          - "php{{ php_version }}-zip"
           - python3-pymysql
+          - mysql-client
         state: present
         update_cache: yes
 

--- a/ansible/playbooks/security-remediation.yml
+++ b/ansible/playbooks/security-remediation.yml
@@ -129,37 +129,6 @@
       changed_when: "'Deleted' in fmgr_delete.stdout"
       failed_when: false
 
-    # -------------------------------------------------------------------------
-    # 5. Webshell scan — uploads/ and former plugin directory
-    # -------------------------------------------------------------------------
-    - name: Scan wp-content/uploads for PHP files (possible webshells)
-      find:
-        paths: "{{ wp_site.path }}/wp-content/uploads"
-        patterns:
-          - "*.php"
-          - "*.phtml"
-          - "*.php7"
-        recurse: true
-      vars:
-        wp_site: "{{ wordpress_installs | selectattr('name', 'equalto', 'pausatf-main') | first }}"
-      register: uploads_php_files
-
-    - name: Warn if PHP files found in uploads directory
-      debug:
-        msg: >
-          WARNING: {{ uploads_php_files.files | length }} PHP file(s) found in uploads/:
-          {{ uploads_php_files.files | map(attribute='path') | join(', ') }}.
-          Review each file immediately and remove any webshells.
-      when: uploads_php_files.files | length > 0
-
-    - name: Confirm no PHP files in uploads directory
-      assert:
-        that: uploads_php_files.files | length == 0
-        fail_msg: >
-          PHP file(s) found in wp-content/uploads — manual review required:
-          {{ uploads_php_files.files | map(attribute='path') | join(', ') }}
-        success_msg: "No PHP files found in wp-content/uploads."
-
     - name: Confirm wp-file-manager-pro plugin directory is gone
       stat:
         path: "{{ wp_site.path }}/wp-content/plugins/wp-file-manager-pro"

--- a/ansible/roles/certbot/handlers/main.yml
+++ b/ansible/roles/certbot/handlers/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Restart Apache
+- name: Restart web server
   service:
-    name: apache2
+    name: "{{ 'apache2' if web_server | default('apache') == 'apache' else 'lsws' }}"
     state: restarted

--- a/ansible/roles/cloudflare/tasks/main.yml
+++ b/ansible/roles/cloudflare/tasks/main.yml
@@ -35,6 +35,7 @@
     dest: /etc/apache2/cloudflare-ips-v4.txt
     mode: '0644'
   register: cf_ips_v4
+  when: web_server | default('apache') == 'apache'
   tags: cloudflare
 
 - name: Update Cloudflare IPv6 ranges
@@ -43,6 +44,7 @@
     dest: /etc/apache2/cloudflare-ips-v6.txt
     mode: '0644'
   register: cf_ips_v6
+  when: web_server | default('apache') == 'apache'
   tags: cloudflare
 
 - name: Verify Cloudflare zone is active

--- a/ansible/roles/lsphp/tasks/main.yml
+++ b/ansible/roles/lsphp/tasks/main.yml
@@ -1,13 +1,20 @@
 # Install LiteSpeed PHP (lsphp) and common extensions
 
-- name: Add LiteSpeed repository key
-  apt_key:
-    url: https://repo.litespeed.sh/ls.key
-    state: present
+- name: Create keyrings directory
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
 
-- name: Add LiteSpeed repo list
+- name: Download LiteSpeed repository key
+  get_url:
+    url: https://repo.litespeed.sh/ls.key
+    dest: /etc/apt/keyrings/litespeed.gpg
+    mode: '0644'
+
+- name: Add LiteSpeed repository
   apt_repository:
-    repo: "deb http://rpms.litespeedtech.com/debian/ stable main"
+    repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/litespeed.gpg] http://rpms.litespeedtech.com/debian/ stable main"
     state: present
     filename: litespeed
 

--- a/ansible/roles/openlitespeed/tasks/main.yml
+++ b/ansible/roles/openlitespeed/tasks/main.yml
@@ -1,14 +1,21 @@
 ---
 # Install and configure OpenLiteSpeed for WordPress
 
-- name: Add LiteSpeed repository
-  apt_key:
-    url: https://repo.litespeed.sh/ls.key
-    state: present
+- name: Create keyrings directory
+  file:
+    path: /etc/apt/keyrings
+    state: directory
+    mode: '0755'
 
-- name: Add LiteSpeed repo list
+- name: Download LiteSpeed repository key
+  get_url:
+    url: https://repo.litespeed.sh/ls.key
+    dest: /etc/apt/keyrings/litespeed.gpg
+    mode: '0644'
+
+- name: Add LiteSpeed repository
   apt_repository:
-    repo: "deb http://rpms.litespeedtech.com/debian/ stable main"
+    repo: "deb [arch=amd64 signed-by=/etc/apt/keyrings/litespeed.gpg] http://rpms.litespeedtech.com/debian/ stable main"
     state: present
     filename: litespeed
 

--- a/ansible/roles/php/defaults/main.yml
+++ b/ansible/roles/php/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-php_version: "7.4"
+php_version: "8.3"

--- a/ansible/roles/wordpress/tasks/main.yml
+++ b/ansible/roles/wordpress/tasks/main.yml
@@ -3,19 +3,14 @@
 # - uses WP-CLI to manage core, plugins, and themes
 # - honors per-install settings in group_vars
 
-- name: Assert WordPress vault secrets are configured
+- name: Assert WordPress credentials are configured
   assert:
     that:
-      - vault_wp_main_db_password is defined and vault_wp_main_db_password | length > 0
-      - vault_wp_main_auth_key is defined and vault_wp_main_auth_key | length > 0
-      - vault_wp_main_secure_auth_key is defined and vault_wp_main_secure_auth_key | length > 0
-      - vault_wp_main_logged_in_key is defined and vault_wp_main_logged_in_key | length > 0
-      - vault_wp_main_nonce_key is defined and vault_wp_main_nonce_key | length > 0
-      - vault_wp_main_auth_salt is defined and vault_wp_main_auth_salt | length > 0
-      - vault_wp_main_secure_auth_salt is defined and vault_wp_main_secure_auth_salt | length > 0
-      - vault_wp_main_logged_in_salt is defined and vault_wp_main_logged_in_salt | length > 0
-      - vault_wp_main_nonce_salt is defined and vault_wp_main_nonce_salt | length > 0
-    fail_msg: "WordPress secrets must be set via Ansible vault — vault_wp_main_* variables are missing or empty"
+      - wordpress_installs is defined
+      - wordpress_installs | length > 0
+      - wordpress_installs[0].db_password | default('') | length > 0
+    fail_msg: "wordpress_installs must be defined with a non-empty db_password"
+  when: wordpress_enabled | default(true)
 
 - name: Assert WordPress auth keys are wired through wordpress_installs
   assert:

--- a/ansible/roles/wordpress/tasks/manage-install.yml
+++ b/ansible/roles/wordpress/tasks/manage-install.yml
@@ -69,9 +69,18 @@
   when: wpcli_update_themes | default(true)
   ignore_errors: yes
 
-- name: Ensure LiteSpeed Cache plugin present and active (stage/dev)
-  command: "{{ wpcli_path | default('/usr/local/bin/wp') }} plugin install litespeed-cache --activate --path={{ wp_site.path }} --allow-root"
+- name: Check if LiteSpeed Cache plugin is installed
+  command: "{{ wpcli_path | default('/usr/local/bin/wp') }} plugin is-installed litespeed-cache --path={{ wp_site.path }} --allow-root"
+  register: lscache_installed
+  changed_when: false
+  failed_when: false
   when: web_server | default('apache') == 'openlitespeed'
+
+- name: Install and activate LiteSpeed Cache plugin (stage/dev)
+  command: "{{ wpcli_path | default('/usr/local/bin/wp') }} plugin install litespeed-cache --activate --path={{ wp_site.path }} --allow-root"
+  when:
+    - web_server | default('apache') == 'openlitespeed'
+    - lscache_installed.rc != 0
 
 - name: Set WordPress file and directory permissions
   file:

--- a/ansible/roles/wordpress/templates/wp-config.php.j2
+++ b/ansible/roles/wordpress/templates/wp-config.php.j2
@@ -43,7 +43,13 @@ define( 'WP_MAX_MEMORY_LIMIT', '{{ wp_site.wp_max_memory_limit | default(wordpre
 define( 'WP_CACHE', true );
 
 // ** WordPress Auto-Updates ** //
-define( 'WP_AUTO_UPDATE_CORE', {{ wp_site.auto_update_core | default('"minor"') }} );
+{% if wp_site.auto_update_core | default('minor') is sameas true %}
+define( 'WP_AUTO_UPDATE_CORE', true );
+{% elif wp_site.auto_update_core | default('minor') is sameas false %}
+define( 'WP_AUTO_UPDATE_CORE', false );
+{% else %}
+define( 'WP_AUTO_UPDATE_CORE', '{{ wp_site.auto_update_core | default("minor") }}' );
+{% endif %}
 
 // ** WordPress Content Directory ** //
 define( 'WP_CONTENT_DIR', dirname(__FILE__) . '/wp-content' );

--- a/ansible/roles/wordpress/templates/wp-update.sh.j2
+++ b/ansible/roles/wordpress/templates/wp-update.sh.j2
@@ -8,7 +8,7 @@
 set -euo pipefail
 
 # Configuration
-WP_PATH="{{ item.path }}"
+WP_PATH="{{ wp_site.path }}"
 WP_USER="{{ apache_user }}"
 WP_CLI="{{ wpcli_path }}"
 LOG_FILE="/var/log/wordpress-updates.log"
@@ -19,7 +19,7 @@ EXCLUDE_PLUGINS=({% for plugin in wpcli_exclude_plugins | default([]) %}"{{ plug
 EXCLUDE_THEMES=({% for theme in wpcli_exclude_themes | default([]) %}"{{ theme }}" {% endfor %})
 
 log() {
-    echo "$(date '+%Y-%m-%d %H:%M:%S') [{{ item.domain }}] $1" >> "$LOG_FILE"
+    echo "$(date '+%Y-%m-%d %H:%M:%S') [{{ wp_site.domain }}] $1" >> "$LOG_FILE"
 }
 
 # Check if already running
@@ -50,9 +50,9 @@ fi
 CURRENT_WP=$(wp_cmd core version)
 log "Current WordPress version: $CURRENT_WP"
 
-{% if item.auto_update_core | default(false) %}
+{% if wp_site.auto_update_core | default(false) %}
 # Update WordPress Core
-{% if item.auto_update_core == "minor" %}
+{% if wp_site.auto_update_core == "minor" %}
 log "Checking for minor core updates..."
 if wp_cmd core check-update --minor 2>/dev/null | grep -q "version"; then
     log "Minor update available, applying..."

--- a/terraform/environments/dev/variables.tf
+++ b/terraform/environments/dev/variables.tf
@@ -31,7 +31,7 @@ variable "droplet_size" {
 variable "droplet_image" {
   description = "Droplet image/snapshot"
   type        = string
-  default     = "ubuntu-22-04-x64"
+  default     = "ubuntu-24-04-x64"
 }
 
 variable "database_size" {

--- a/terraform/environments/github/main.tf
+++ b/terraform/environments/github/main.tf
@@ -11,7 +11,7 @@ terraform {
   backend "s3" {
     bucket                      = "pausatf-terraform-state"
     key                         = "github/terraform.tfstate"
-    region                      = "us-west-2"
+    region                      = "us-west-1"
     endpoint                    = "sfo2.digitaloceanspaces.com"
     skip_credentials_validation = true
     skip_metadata_api_check     = true


### PR DESCRIPTION
## Summary

**4 Blockers fixed:**
- WordPress vault assertion hard-coded `vault_wp_main_*` — replaced with generic `wordpress_installs[0]` validation (unblocks staging/dev deploys)
- Duplicate webshell scan in security-remediation.yml — removed redundant first scan, kept loop-based one
- `php8.3-fpm` hard-coded in rebuild playbook post_tasks — now `php{{ php_version }}-fpm`
- `openlitespeed` and `lsphp` roles used deprecated `apt_key` — converted to `signed-by` keyrings

**7 Major fixes:**
- Cloudflare IP file downloads gated on `web_server == apache` (prevented failure on OLS hosts)
- `WP_AUTO_UPDATE_CORE` now produces properly quoted PHP value (was bare `minor` token)
- restore-prod.yml uses versioned PHP packages, removes `php-xmlrpc` and `mysql-server`
- LiteSpeed Cache install made idempotent (check-before-install)
- `web_server: apache` added to production group_vars (was only in inventory host_vars)
- `mysql_version` normalized to `"8"` across all environments
- `wp-update.sh.j2` loop variable fixed (`item` → `wp_site`)

**6 Minor fixes:**
- `setup-tflint` pinned to SHA
- Dev TF `droplet_image` fixed to `ubuntu-24-04-x64`
- GitHub TF backend region normalized to `us-west-1`
- PHP role default updated from 7.4 to 8.3
- Certbot handler made web_server-aware

## Test plan
- [ ] `ansible-lint` passes
- [ ] `terraform validate` passes in all 5 environments
- [ ] WordPress role assertion passes for staging/dev (no `vault_wp_main_*` dependency)
- [ ] LiteSpeed Cache install is idempotent on re-run