### PR TITLE
refactor: DRY WordPress defaults, Terraform backend, PHP modules

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -131,7 +131,7 @@ php_upload_max_filesize: "64M"
 php_post_max_size: "64M"
 php_date_timezone: "America/Los_Angeles"
 
-# PHP modules to ensure installed
+# PHP modules to ensure installed (used by both php and php-fpm roles)
 php_modules:
   - bcmath
   - cli
@@ -139,10 +139,11 @@ php_modules:
   - curl
   - gd
   - imagick
-  - json
+  - intl
   - mbstring
   - mysql
   - opcache
+  - redis
   - soap
   - xml
   - zip
@@ -164,6 +165,26 @@ mysql_version: "8"
 mysql_managed: true
 mysql_enabled: false
 mysql_port: 25060  # DO Managed MySQL default port
+
+# =============================================================================
+# WORDPRESS INSTALL DEFAULTS
+# =============================================================================
+# Shared defaults for all environments. Per-environment group_vars override
+# only the keys that differ (domain, db_password, auth keys, etc.).
+# Usage in env group_vars: wordpress_install_defaults | combine({...})
+wordpress_install_defaults:
+  name: "pausatf-main"
+  path: "/var/www/html"
+  db_name: "wordpress"
+  db_user: "wordpress"
+  db_host: "localhost"
+  table_prefix: "wp_"
+  active_theme: "TheSource-child"
+  cron_enabled: true
+  disallow_file_edit: true
+  disallow_file_mods: false
+  auto_update_core: "minor"
+  fs_method: "direct"
 
 # =============================================================================
 # WP-CLI CONFIGURATION

--- a/ansible/group_vars/dev.yml
+++ b/ansible/group_vars/dev.yml
@@ -4,28 +4,19 @@ web_server: openlitespeed
 php_version: "8.4"
 mysql_version: "8"
 
+# WordPress — dev overrides merged with defaults from all.yml
 wordpress_installs:
-  - name: "pausatf-main"
-    domain: "dev.pausatf.org"
-    path: "/var/www/html"
-    db_name: "wordpress"
-    db_user: "wordpress"
-    db_password: "{{ vault_wp_dev_db_password }}"
-    db_host: "localhost"
-    table_prefix: "wp_"
-    wp_version: "latest"
-    active_theme: "TheSource-child"
-    cron_enabled: true
-    debug_mode: true
-    disallow_file_edit: true
-    disallow_file_mods: false
-    auto_update_core: "minor"
-    fs_method: "direct"
-    auth_key: "{{ vault_wp_dev_auth_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
-    secure_auth_key: "{{ vault_wp_dev_secure_auth_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
-    logged_in_key: "{{ vault_wp_dev_logged_in_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
-    nonce_key: "{{ vault_wp_dev_nonce_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
-    auth_salt: "{{ vault_wp_dev_auth_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
-    secure_auth_salt: "{{ vault_wp_dev_secure_auth_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
-    logged_in_salt: "{{ vault_wp_dev_logged_in_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
-    nonce_salt: "{{ vault_wp_dev_nonce_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+  - "{{ wordpress_install_defaults | combine({
+      'domain': 'dev.pausatf.org',
+      'wp_version': 'latest',
+      'debug_mode': true,
+      'db_password': vault_wp_dev_db_password,
+      'auth_key': vault_wp_dev_auth_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+      'secure_auth_key': vault_wp_dev_secure_auth_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+      'logged_in_key': vault_wp_dev_logged_in_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+      'nonce_key': vault_wp_dev_nonce_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+      'auth_salt': vault_wp_dev_auth_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+      'secure_auth_salt': vault_wp_dev_secure_auth_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+      'logged_in_salt': vault_wp_dev_logged_in_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+      'nonce_salt': vault_wp_dev_nonce_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+    }) }}"

--- a/ansible/group_vars/production/main.yml
+++ b/ansible/group_vars/production/main.yml
@@ -67,42 +67,30 @@ web_server: apache
 # =============================================================================
 # WORDPRESS — PRODUCTION INSTALL
 # =============================================================================
-# Full install definition with production DB, SSL paths, and vault-sourced
-# auth keys. Dev/staging override this block entirely in their own group_vars.
+# Production-specific overrides merged with shared defaults from all.yml.
+# Dev/staging define their own wordpress_installs in their group_vars.
 wordpress_installs:
-  - name: "pausatf-main"
-    domain: "www.pausatf.org"
-    aliases:
-      - "pausatf.org"
-    path: "/var/www/html"
-    db_name: "wordpress"
-    db_user: "wordpress"
-    db_password: "{{ vault_wp_main_db_password }}"
-    db_host: "localhost"
-    table_prefix: "wp_"
-    wp_version: "6.8.3"
-    wp_memory_limit: "256M"
-    wp_max_memory_limit: "512M"
-    ssl_enabled: true
-    ssl_certificate: "/etc/letsencrypt/live/pausatf.org/fullchain.pem"
-    ssl_certificate_key: "/etc/letsencrypt/live/pausatf.org/privkey.pem"
-    active_theme: "TheSource-child"
-    cron_enabled: true
-    debug_mode: false
-    disallow_file_edit: true
-    disallow_file_mods: false
-    auto_update_core: "minor"
-    fs_method: "direct"
-    manage_wp_config: true
-    # Auth keys and salts — sourced from vault; never hardcode
-    auth_key: "{{ vault_wp_main_auth_key }}"
-    secure_auth_key: "{{ vault_wp_main_secure_auth_key }}"
-    logged_in_key: "{{ vault_wp_main_logged_in_key }}"
-    nonce_key: "{{ vault_wp_main_nonce_key }}"
-    auth_salt: "{{ vault_wp_main_auth_salt }}"
-    secure_auth_salt: "{{ vault_wp_main_secure_auth_salt }}"
-    logged_in_salt: "{{ vault_wp_main_logged_in_salt }}"
-    nonce_salt: "{{ vault_wp_main_nonce_salt }}"
+  - "{{ wordpress_install_defaults | combine({
+      'domain': 'www.pausatf.org',
+      'aliases': ['pausatf.org'],
+      'wp_version': '6.8.3',
+      'debug_mode': false,
+      'wp_memory_limit': '256M',
+      'wp_max_memory_limit': '512M',
+      'ssl_enabled': true,
+      'ssl_certificate': '/etc/letsencrypt/live/pausatf.org/fullchain.pem',
+      'ssl_certificate_key': '/etc/letsencrypt/live/pausatf.org/privkey.pem',
+      'manage_wp_config': true,
+      'db_password': vault_wp_main_db_password,
+      'auth_key': vault_wp_main_auth_key,
+      'secure_auth_key': vault_wp_main_secure_auth_key,
+      'logged_in_key': vault_wp_main_logged_in_key,
+      'nonce_key': vault_wp_main_nonce_key,
+      'auth_salt': vault_wp_main_auth_salt,
+      'secure_auth_salt': vault_wp_main_secure_auth_salt,
+      'logged_in_salt': vault_wp_main_logged_in_salt,
+      'nonce_salt': vault_wp_main_nonce_salt,
+    }) }}"
 
 # =============================================================================
 # WORDPRESS THEMES (production site)

--- a/ansible/group_vars/staging.yml
+++ b/ansible/group_vars/staging.yml
@@ -4,29 +4,19 @@ web_server: openlitespeed
 php_version: "8.4"
 mysql_version: "8"
 
-# WordPress core on staging follows latest minor
+# WordPress — staging overrides merged with defaults from all.yml
 wordpress_installs:
-  - name: "pausatf-main"
-    domain: "stage.pausatf.org"
-    path: "/var/www/html"
-    db_name: "wordpress"
-    db_user: "wordpress"
-    db_password: "{{ vault_wp_stage_db_password }}"
-    db_host: "localhost"
-    table_prefix: "wp_"
-    wp_version: "latest"
-    active_theme: "TheSource-child"
-    cron_enabled: true
-    debug_mode: false
-    disallow_file_edit: true
-    disallow_file_mods: false
-    auto_update_core: "minor"
-    fs_method: "direct"
-    auth_key: "{{ vault_wp_stage_auth_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
-    secure_auth_key: "{{ vault_wp_stage_secure_auth_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
-    logged_in_key: "{{ vault_wp_stage_logged_in_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
-    nonce_key: "{{ vault_wp_stage_nonce_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
-    auth_salt: "{{ vault_wp_stage_auth_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
-    secure_auth_salt: "{{ vault_wp_stage_secure_auth_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
-    logged_in_salt: "{{ vault_wp_stage_logged_in_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
-    nonce_salt: "{{ vault_wp_stage_nonce_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')) }}"
+  - "{{ wordpress_install_defaults | combine({
+      'domain': 'stage.pausatf.org',
+      'wp_version': 'latest',
+      'debug_mode': false,
+      'db_password': vault_wp_stage_db_password,
+      'auth_key': vault_wp_stage_auth_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+      'secure_auth_key': vault_wp_stage_secure_auth_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+      'logged_in_key': vault_wp_stage_logged_in_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+      'nonce_key': vault_wp_stage_nonce_key | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+      'auth_salt': vault_wp_stage_auth_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+      'secure_auth_salt': vault_wp_stage_secure_auth_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+      'logged_in_salt': vault_wp_stage_logged_in_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+      'nonce_salt': vault_wp_stage_nonce_salt | default(lookup('password', '/dev/null length=64 chars=ascii_letters,digits,punctuation')),
+    }) }}"

--- a/ansible/roles/php-fpm/tasks/main.yml
+++ b/ansible/roles/php-fpm/tasks/main.yml
@@ -9,22 +9,14 @@
 
 - name: Install PHP {{ php_version }}-FPM and extensions
   apt:
-    name:
-      - php{{ php_version }}-fpm
-      - php{{ php_version }}-mysql
-      - php{{ php_version }}-redis
-      - php{{ php_version }}-curl
-      - php{{ php_version }}-xml
-      - php{{ php_version }}-mbstring
-      - php{{ php_version }}-zip
-      - php{{ php_version }}-gd
-      - php{{ php_version }}-intl
-      - php{{ php_version }}-soap
-      - php{{ php_version }}-bcmath
-      - php{{ php_version }}-imagick
-      - php{{ php_version }}-opcache
-      - php{{ php_version }}-cli
+    name: "{{ _php_packages }}"
     state: present
+  vars:
+    _php_module_packages: "{{ php_modules | map('regex_replace', '^(.*)$', 'php' + php_version + '-\\1') | list }}"
+    _php_extra_packages:
+      - "php{{ php_version }}-fpm"
+      - "php{{ php_version }}-memcached"
+    _php_packages: "{{ _php_module_packages + _php_extra_packages }}"
 
 - name: Remove mod_php if installed
   apt:

--- a/ansible/roles/php/tasks/main.yml
+++ b/ansible/roles/php/tasks/main.yml
@@ -13,23 +13,11 @@
     state: present
   notify: Restart Apache
   vars:
-    _php_base_packages:
-      - "php{{ php_version }}"
-      - "php{{ php_version }}-cli"
-      - "php{{ php_version }}-common"
-      - "php{{ php_version }}-curl"
-      - "php{{ php_version }}-gd"
-      - "php{{ php_version }}-imagick"
-      - "php{{ php_version }}-mbstring"
-      - "php{{ php_version }}-mysql"
-      - "php{{ php_version }}-opcache"
-      - "php{{ php_version }}-soap"
-      - "php{{ php_version }}-xml"
-      - "php{{ php_version }}-zip"
-      - "php{{ php_version }}-bcmath"
+    _php_module_packages: "{{ php_modules | map('regex_replace', '^(.*)$', 'php' + php_version + '-\\1') | list }}"
+    _php_extra_packages:
       - "libapache2-mod-php{{ php_version }}"
     _php_legacy_packages: "{{ ['php' + php_version + '-json'] if php_version is version('8.0', '<') else [] }}"
-    _php_packages: "{{ _php_base_packages + _php_legacy_packages }}"
+    _php_packages: "{{ _php_module_packages + _php_extra_packages + _php_legacy_packages }}"
 
 - name: Deploy PHP {{ php_version }} configuration
   template:

--- a/scripts/terraform-wrapper.sh
+++ b/scripts/terraform-wrapper.sh
@@ -117,7 +117,7 @@ run_terraform() {
 
     case "$ACTION" in
         init)
-            terraform init
+            terraform init -backend-config="$ROOT_DIR/terraform/backend.hcl"
             ;;
         validate)
             terraform validate

--- a/terraform/backend.hcl
+++ b/terraform/backend.hcl
@@ -1,0 +1,9 @@
+# Shared S3 backend configuration for DigitalOcean Spaces
+# Used by all environments via: terraform init -backend-config=../../backend.hcl
+endpoint                    = "sfo2.digitaloceanspaces.com"
+region                      = "us-west-1"
+bucket                      = "pausatf-terraform-state"
+skip_credentials_validation = true
+skip_metadata_api_check     = true
+skip_region_validation      = true
+use_lockfile                = true

--- a/terraform/environments/cloudflare/main.tf
+++ b/terraform/environments/cloudflare/main.tf
@@ -9,15 +9,7 @@ terraform {
   }
 
   backend "s3" {
-    # DigitalOcean Spaces backend
-    endpoint                    = "sfo2.digitaloceanspaces.com"
-    region                      = "us-west-1"
-    bucket                      = "pausatf-terraform-state"
-    key                         = "cloudflare/terraform.tfstate"
-    skip_credentials_validation = true
-    skip_metadata_api_check     = true
-    skip_region_validation      = true
-    use_lockfile                = true
+    key = "cloudflare/terraform.tfstate"
   }
 }
 

--- a/terraform/environments/dev/main.tf
+++ b/terraform/environments/dev/main.tf
@@ -13,14 +13,7 @@ terraform {
   }
 
   backend "s3" {
-    endpoint                    = "sfo2.digitaloceanspaces.com"
-    region                      = "us-west-1"
-    bucket                      = "pausatf-terraform-state"
-    key                         = "dev/terraform.tfstate"
-    skip_credentials_validation = true
-    skip_metadata_api_check     = true
-    skip_region_validation      = true
-    use_lockfile                = true
+    key = "dev/terraform.tfstate"
   }
 }
 

--- a/terraform/environments/github/main.tf
+++ b/terraform/environments/github/main.tf
@@ -9,14 +9,7 @@ terraform {
   }
 
   backend "s3" {
-    bucket                      = "pausatf-terraform-state"
-    key                         = "github/terraform.tfstate"
-    region                      = "us-west-1"
-    endpoint                    = "sfo2.digitaloceanspaces.com"
-    skip_credentials_validation = true
-    skip_metadata_api_check     = true
-    skip_region_validation      = true
-    use_lockfile                = true
+    key = "github/terraform.tfstate"
   }
 }
 

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -13,15 +13,7 @@ terraform {
   }
 
   backend "s3" {
-    # DigitalOcean Spaces backend
-    endpoint                    = "sfo2.digitaloceanspaces.com"
-    region                      = "us-west-1" # Dummy region for DO Spaces
-    bucket                      = "pausatf-terraform-state"
-    key                         = "production/terraform.tfstate"
-    skip_credentials_validation = true
-    skip_metadata_api_check     = true
-    skip_region_validation      = true
-    use_lockfile                = true
+    key = "production/terraform.tfstate"
   }
 }
 

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -13,15 +13,7 @@ terraform {
   }
 
   backend "s3" {
-    # DigitalOcean Spaces backend
-    endpoint                    = "sfo2.digitaloceanspaces.com"
-    region                      = "us-west-1"
-    bucket                      = "pausatf-terraform-state"
-    key                         = "staging/terraform.tfstate"
-    skip_credentials_validation = true
-    skip_metadata_api_check     = true
-    skip_region_validation      = true
-    use_lockfile                = true
+    key = "staging/terraform.tfstate"
   }
 }
 


### PR DESCRIPTION
## Summary

- Extract `wordpress_install_defaults` dict into `all.yml`; staging, dev, and production now use `combine()` to override only per-environment keys (domain, secrets, debug flags), eliminating ~60 duplicated lines
- Create `terraform/backend.hcl` partial config with shared S3 backend attributes; all 5 environment backends reduced to just the `key` parameter, updated `terraform-wrapper.sh` to pass `-backend-config`
- Derive PHP package lists from the `php_modules` variable via `map('regex_replace')` in both `php` and `php-fpm` roles; remove `json` module (built-in since PHP 8.0), add `intl` and `redis`

## Test plan

- [ ] `ansible-playbook --syntax-check` on all playbooks
- [ ] `terraform init -backend=false && terraform validate` in each environment
- [ ] Verify `terraform-wrapper.sh` passes `--backend-config` correctly
- [ ] Confirm PHP package list resolves correctly for PHP 8.3