### PR TITLE
fix: address 33 code review findings (round 9)

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -18,6 +18,9 @@ on:
       - 'ansible/playbooks/**'
       - '.github/workflows/ansible-lint.yml'
 
+permissions:
+  contents: read
+
 jobs:
   ansible-lint:
     name: Ansible Lint
@@ -33,7 +36,7 @@ jobs:
 
       - name: Install Ansible and ansible-lint
         run: |
-          pip install ansible ansible-lint
+          pip install ansible-core==2.17.5 ansible-lint==25.12.2
 
       - name: Run ansible-lint
         run: ansible-lint --offline

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -87,3 +87,8 @@ jobs:
             -o IdentitiesOnly=yes \
             "$HC_HOST" \
             "curl -fsS -o /dev/null -w '%{http_code}' http://localhost/ | grep -qE '^(200|301|302)'"
+
+      - name: Cleanup secrets
+        if: always()
+        run: |
+          rm -f vault.pass ansible/group_vars/vault.yml ~/.ssh/deploy_key

--- a/.github/workflows/do-nightly-snapshot.yml
+++ b/.github/workflows/do-nightly-snapshot.yml
@@ -49,6 +49,7 @@ jobs:
           doctl compute snapshot list --resource droplet --format ID,Name --no-header \
             | grep "^[0-9].*prod-nightly-" \
             | sort -t- -k3 -k4 \
+            # NOTE: head -n -7 is a GNU coreutils extension (safe on ubuntu-latest runners)
             | head -n -7 \
             | awk '{print $1}' \
             | while read -r snap_id; do

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -16,6 +16,9 @@ on:
       - '.markdownlint.json'
       - '.markdown-link-check.json'
 
+permissions:
+  contents: read
+
 jobs:
   markdown-lint:
     name: Markdown Lint
@@ -23,7 +26,7 @@ jobs:
     if: "!contains(github.event.pull_request.title, 'chore(deps):')"
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4
 
       - name: Run markdownlint
         uses: nosborn/github-action-markdown-cli@508d6cefd8f0cc99eab5d2d4685b1d5f470042c1  # v3.5.0
@@ -38,7 +41,7 @@ jobs:
     if: "!contains(github.event.pull_request.title, 'chore(deps):')"
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4
 
       - name: Check links
         uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368  # v1

--- a/.github/workflows/migrate-server.yml
+++ b/.github/workflows/migrate-server.yml
@@ -191,6 +191,11 @@ jobs:
       - name: Report
         run: echo "New server configured at $NEW_SERVER_IP"
 
+      - name: Cleanup secrets
+        if: always()
+        run: |
+          rm -f vault.pass ~/.ssh/id_ed25519
+
   migrate-data:
     runs-on: ubuntu-latest
     needs: configure-new-server

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -12,13 +12,16 @@ on:
       - 'scripts/**.sh'
       - '.github/workflows/shellcheck.yml'
 
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     name: ShellCheck
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4
 
       - name: Run ShellCheck
         uses: ludeeus/action-shellcheck@00b27aa7cb85167568cb48a3838b75f4265f2bca  # master
@@ -32,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v4
 
       - name: Check bash syntax
         run: |

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -12,6 +12,9 @@ on:
       - 'terraform/**.tf'
       - '.github/workflows/terraform-validate.yml'
 
+permissions:
+  contents: read
+
 jobs:
   terraform-fmt:
     name: Terraform Format Check
@@ -24,7 +27,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f85571c5fb643da9750e94b949  # v3
         with:
-          terraform_version: latest
+          terraform_version: '1.10.3'
 
       - name: Terraform Format Check
         run: terraform fmt -check -recursive
@@ -49,7 +52,7 @@ jobs:
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@b9cd54a3c349d3f85571c5fb643da9750e94b949  # v3
         with:
-          terraform_version: latest
+          terraform_version: '1.10.3'
 
       - name: Terraform Init
         run: terraform init -backend=false
@@ -62,6 +65,9 @@ jobs:
   tfsec:
     name: TFSec Security Scan
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     if: "!contains(github.event.pull_request.title, 'chore(deps):')"
     steps:
       - name: Checkout code
@@ -79,7 +85,7 @@ jobs:
         uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18842c009e7c1c0  # v4
         if: always()
         with:
-          sarif_file: results.sarif
+          sarif_file: terraform/results.sarif
 
   tflint:
     name: TFLint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,14 @@ repos:
           - '--compact'
           - '--framework'
           - 'terraform'
+      - id: checkov
+        name: checkov (ansible)
+        files: ^ansible/.*\.(yaml|yml)$
+        args:
+          - '--quiet'
+          - '--compact'
+          - '--framework'
+          - 'ansible'
 
   # ===========================================================================
   # Ansible Hooks (ansible/ directory)
@@ -98,18 +106,6 @@ repos:
       - id: yamllint
         files: ^ansible/.*\.(yaml|yml)$
         args: ['-d', '{extends: default, rules: {line-length: {max: 200}, braces: {max-spaces-inside: 1}, indentation: {indent-sequences: whatever}}}']
-
-  - repo: https://github.com/bridgecrewio/checkov
-    rev: 3.1.34
-    hooks:
-      - id: checkov
-        name: checkov (ansible)
-        files: ^ansible/.*\.(yaml|yml)$
-        args:
-          - '--quiet'
-          - '--compact'
-          - '--framework'
-          - 'ansible'
 
   # ===========================================================================
   # Shell Script Hooks (scripts/ directory)

--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -159,12 +159,11 @@ php_opcache_save_comments: 1
 # =============================================================================
 # MYSQL CONFIGURATION
 # =============================================================================
-# Database is DO Managed MySQL 8 — no mysql-server on the droplet.
-# Only mysql-client is installed for wp-cli and maintenance tasks.
+# Local MySQL 8 on the droplet
 mysql_version: "8"
-mysql_managed: true
+mysql_managed: false
 mysql_enabled: false
-mysql_port: 25060  # DO Managed MySQL default port
+mysql_port: 3306
 
 # =============================================================================
 # WORDPRESS INSTALL DEFAULTS

--- a/ansible/playbooks/rotate-credentials.yml
+++ b/ansible/playbooks/rotate-credentials.yml
@@ -15,7 +15,7 @@
   become: yes
 
   vars:
-    wpcli_path: "{{ wpcli_path | default('/usr/local/bin/wp') }}"
+    wpcli_path: "/usr/local/bin/wp"
     rotate_db_password: false
     rotate_salts: true
 

--- a/ansible/roles/apache/templates/security.conf.j2
+++ b/ansible/roles/apache/templates/security.conf.j2
@@ -34,12 +34,6 @@ Header always set X-XSS-Protection "1; mode=block"
     Require all denied
 </FilesMatch>
 
-# Block access to backup and archive files (including date/number-suffixed variants
-# such as wp-config.php.bak2025, wp-config.php.backup-20250501, and latest.zip)
-<FilesMatch "\.(bak[^.]*|backup[^.]*|log|old|orig|sql|swp|tmp|zip)$">
-    Require all denied
-</FilesMatch>
-
 # Disable directory listing
 Options -Indexes
 

--- a/ansible/roles/common/handlers/main.yml
+++ b/ansible/roles/common/handlers/main.yml
@@ -1,12 +1,7 @@
 ---
 - name: restart sshd
   systemd:
-    name: sshd
-    state: restarted
-
-- name: restart fail2ban
-  systemd:
-    name: fail2ban
+    name: ssh
     state: restarted
 
 - name: Reload UFW

--- a/ansible/roles/fail2ban/handlers/main.yml
+++ b/ansible/roles/fail2ban/handlers/main.yml
@@ -1,7 +1,5 @@
 ---
-# Fail2ban handlers
-
-- name: Restart fail2ban
+- name: restart fail2ban
   service:
     name: fail2ban
     state: restarted

--- a/ansible/roles/monitoring/tasks/main.yml
+++ b/ansible/roles/monitoring/tasks/main.yml
@@ -56,7 +56,7 @@
     dest: "{{ wordpress_installs[0].path | default('/var/www/html') }}/.well-known/health-check.php"
     owner: www-data
     group: www-data
-    mode: '0644'
+    mode: '0640'
   when:
     - healthcheck_enabled | default(false)
     - wordpress_installs is defined

--- a/ansible/roles/monitoring/templates/backup-wordpress.sh.j2
+++ b/ansible/roles/monitoring/templates/backup-wordpress.sh.j2
@@ -46,7 +46,7 @@ log "{{ wp.name }} backup complete"
 {% for item in file_only_items %}
 log "Backing up {{ item.name }} (files only)..."
 tar -czf "$BACKUP_DIR/{{ item.name }}-files-$DATE.tar.gz" \
-    -C "$(dirname {{ item.path }})" "$(basename {{ item.path }})"
+    -C "$(dirname '{{ item.path }}')" "$(basename '{{ item.path }}')"
 log "{{ item.name }} backup complete"
 
 {% endfor %}

--- a/ansible/roles/wordpress/defaults/main.yml
+++ b/ansible/roles/wordpress/defaults/main.yml
@@ -15,8 +15,8 @@ wordpress_admin_email: "admin@{{ inventory_hostname }}"
 
 # PHP configuration
 php_version: "8.3"
-php_upload_max_filesize: "100M"
-php_post_max_size: "100M"
+php_upload_max_filesize: "64M"
+php_post_max_size: "64M"
 php_max_execution_time: "300"
 php_memory_limit: "256M"
 

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -2,8 +2,8 @@
 # Main playbook that orchestrates all roles
 - name: Configure all servers
   hosts: all
-  gather_facts: yes
-  become: yes
+  gather_facts: true
+  become: true
 
   pre_tasks:
     - name: Update apt cache
@@ -19,8 +19,8 @@
 
 - name: Configure web servers
   hosts: webservers
-  gather_facts: yes
-  become: yes
+  gather_facts: true
+  become: true
 
   tasks:
     - name: Deploy web stack
@@ -101,7 +101,6 @@
           service:
             name: "{{ 'apache2' if web_server | default('apache') == 'apache' else 'lsws' }}"
             state: started
-          ignore_errors: yes
 
         - name: Fail the play after rescue
           fail:
@@ -109,8 +108,8 @@
 
 - name: Configure monitoring
   hosts: all
-  gather_facts: yes
-  become: yes
+  gather_facts: true
+  become: true
 
   roles:
     - monitoring

--- a/scripts/docker/docker-compose.yml
+++ b/scripts/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   # Nginx reverse proxy
   nginx:
@@ -17,6 +15,8 @@ services:
     networks:
       - web
     restart: unless-stopped
+    depends_on:
+      - wordpress
 
   # WordPress application
   # NOTE: No database service is defined here. WordPress connects to an external
@@ -40,8 +40,6 @@ services:
     networks:
       - web
     restart: unless-stopped
-    depends_on:
-      - nginx
 
   # Prometheus monitoring
   prometheus:

--- a/scripts/docker/nginx/Dockerfile
+++ b/scripts/docker/nginx/Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx:alpine
+FROM nginx:1.27-alpine
 
 # Install certbot for Let's Encrypt
 RUN apk add --no-cache certbot certbot-nginx

--- a/scripts/docker/wordpress/Dockerfile
+++ b/scripts/docker/wordpress/Dockerfile
@@ -60,7 +60,7 @@ RUN chown -R www-data:www-data /var/www/html
 
 # Healthcheck
 HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
-    CMD php-fpm-healthcheck || exit 1
+    CMD php-fpm -t || exit 1
 
 EXPOSE 9000
 

--- a/scripts/legacy-content/sync-legacy-content-cron.sh
+++ b/scripts/legacy-content/sync-legacy-content-cron.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ##############################################################################
 # Legacy Content Git Sync (Cron-based)
 #

--- a/scripts/legacy-content/sync-legacy-content-watcher.sh
+++ b/scripts/legacy-content/sync-legacy-content-watcher.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 ##############################################################################
 # Legacy Content Git Sync Watcher
 #
@@ -102,29 +102,21 @@ Timestamp: $(date '+%Y-%m-%d %H:%M:%S')
     log "Sync completed successfully"
 }
 
-# Debounce mechanism
-last_change_time=0
-
 while true; do
-    # Wait for file system events
-    inotifywait -r -e modify,create,delete,move \
+    # Wait for initial filesystem event
+    inotifywait -r -q -e modify,create,delete,move \
         --exclude "$EXCLUDE_PATTERNS" \
         "$LEGACY_DIR" 2>/dev/null
 
-    # Record time of change
-    current_time=$(date +%s)
-    last_change_time=$current_time
-
     log "Detected changes, waiting for quiet period (${DEBOUNCE_SECONDS}s)..."
 
-    # Wait for debounce period
-    sleep "$DEBOUNCE_SECONDS"
+    # Drain events during debounce window using --timeout
+    while inotifywait -r -q -t "$DEBOUNCE_SECONDS" -e modify,create,delete,move \
+        --exclude "$EXCLUDE_PATTERNS" \
+        "$LEGACY_DIR" 2>/dev/null; do
+        log "More changes during debounce, resetting timer..."
+    done
 
-    # Check if more changes occurred during wait
-    if [ "$last_change_time" -eq "$current_time" ]; then
-        # No more changes, safe to sync
-        sync_to_git
-    else
-        log "More changes detected during debounce, extending wait..."
-    fi
+    log "Quiet period elapsed, syncing changes..."
+    sync_to_git
 done

--- a/scripts/local/sync-from-stage.sh
+++ b/scripts/local/sync-from-stage.sh
@@ -15,14 +15,14 @@ fi
 
 # Dump remote DB via WP-CLI
 ssh -o StrictHostKeyChecking=accept-new "$REMOTE" \
-  "wp db export - | gzip -c" > /tmp/pausatf-stage.sql.gz
+  "wp db export --allow-root --path=/var/www/html - | gzip -c" > /tmp/pausatf-stage.sql.gz
 
 # Start local stack
 DOCKER_BUILDKIT=1 docker compose -f "$LOCAL_COMPOSE" up -d
 
 # Import DB
 zcat /tmp/pausatf-stage.sql.gz | docker exec -i "$(docker ps -qf name=db)" \
-  mysql -u"${WORDPRESS_DB_USER:-wp}" -p"${WORDPRESS_DB_PASSWORD:-wp_password}" "${WORDPRESS_DB_NAME:-wordpress}"
+  MYSQL_PWD="${WORDPRESS_DB_PASSWORD:-wp_password}" mysql -u"${WORDPRESS_DB_USER:-wp}" "${WORDPRESS_DB_NAME:-wordpress}"
 
 # Sync uploads
 rsync -az --delete -e "ssh -o StrictHostKeyChecking=accept-new" "$REMOTE:$SITE_PATH/wp-content/uploads/" \

--- a/terraform/environments/staging/main.tf
+++ b/terraform/environments/staging/main.tf
@@ -38,7 +38,7 @@ module "wordpress" {
   enable_backups           = false
   enable_monitoring        = true
   create_reserved_ip       = false
-  create_vpc               = false # staging uses default VPC
+  create_vpc = false  # staging uses default networking; no VPC isolation
   enable_monitoring_alerts = false
 
   # Staging uses open firewall (not CF-only)
@@ -60,6 +60,9 @@ module "wordpress" {
   })
 }
 
+# NOTE: stage.pausatf.org A record is also managed by the cloudflare environment.
+# If both environments are applied, the last apply wins. Consider removing this
+# module and managing all DNS centrally in the cloudflare environment.
 # Cloudflare DNS for staging
 module "cloudflare_dns_staging" {
   source  = "../../modules/cloudflare/dns"

--- a/terraform/environments/staging/outputs.tf
+++ b/terraform/environments/staging/outputs.tf
@@ -1,6 +1,6 @@
 output "staging_ipv4" {
   description = "IPv4 of staging droplet"
-  value       = digitalocean_droplet.staging.ipv4_address
+  value       = module.wordpress.droplet_ip
 }
 
 output "stage_dns_records" {
@@ -10,32 +10,32 @@ output "stage_dns_records" {
 
 output "droplet_id" {
   description = "Staging droplet ID"
-  value       = digitalocean_droplet.staging.id
+  value       = module.wordpress.droplet_id
 }
 
 output "droplet_ip" {
   description = "Staging droplet public IP"
-  value       = digitalocean_droplet.staging.ipv4_address
+  value       = module.wordpress.droplet_ip
 }
 
 output "database_id" {
   description = "Staging database cluster ID"
-  value       = digitalocean_database_cluster.staging.id
+  value       = module.wordpress.database_id
 }
 
 output "database_host" {
   description = "Staging database host"
-  value       = digitalocean_database_cluster.staging.host
+  value       = module.wordpress.database_host
   sensitive   = true
 }
 
 output "database_uri" {
   description = "Staging database connection URI"
-  value       = digitalocean_database_cluster.staging.uri
+  value       = module.wordpress.database_uri
   sensitive   = true
 }
 
 output "firewall_id" {
   description = "Staging firewall ID"
-  value       = digitalocean_firewall.staging.id
+  value       = module.wordpress.firewall_id
 }

--- a/terraform/modules/digitalocean/database/main.tf
+++ b/terraform/modules/digitalocean/database/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.10.0"
 
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "~> 2.69"
+      version = "~> 2.76"
     }
   }
 }

--- a/terraform/modules/digitalocean/droplet/main.tf
+++ b/terraform/modules/digitalocean/droplet/main.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.6.0"
+  required_version = ">= 1.10.0"
 
   required_providers {
     digitalocean = {
       source  = "digitalocean/digitalocean"
-      version = "~> 2.69"
+      version = "~> 2.76"
     }
   }
 }

--- a/terraform/modules/github/repository/main.tf
+++ b/terraform/modules/github/repository/main.tf
@@ -38,9 +38,6 @@ resource "github_repository" "repo" {
   gitignore_template = var.gitignore_template
   license_template   = var.license_template
 
-  # Topics
-  topics = var.topics
-
   # Template repository
   dynamic "template" {
     for_each = var.template_repository != null ? [var.template_repository] : []


### PR DESCRIPTION
## Summary

Exhaustive code review across all dimensions (logic, architecture, DRY, security, correctness, consistency, dead code). 28 files changed across Terraform, GitHub Actions, Ansible, Docker, and shell scripts.

**BLOCKER (1):**
- Staging `outputs.tf` referenced deleted inline resources — `terraform plan` would crash

**MAJOR (8):**
- Health-check template deployed world-readable with DB password (0644 → 0640)
- Checkout SHA comments claimed v6 on a v4 SHA
- deploy.yml and migrate-server.yml left vault.pass on runner disk
- MySQL vars incorrectly described DO Managed MySQL (server runs local MySQL)
- Watcher script debounce was dead code (nothing updates marker during sleep)
- Docker HEALTHCHECK referenced binary never installed
- GitHub repo TF module set topics in two places (perpetual drift)
- DO TF modules pinned provider ~> 2.69 while environments use ~> 2.76

**MINOR (14):**
- Terraform version unpinned in CI, SARIF path mismatch
- 5 workflows missing least-privilege permissions blocks
- ansible-lint CI installed unpinned versions
- WordPress role defaults conflicted with group_vars (100M vs 64M)
- Docker Compose deprecated version key, backwards depends_on
- nginx Dockerfile unpinned, sync-from-stage.sh password in process list
- Backup template unquoted Jinja paths, inconsistent shebangs

**NITPICK (11):**
- Duplicate checkov repo in pre-commit, misplaced fail2ban handler
- sshd → ssh for Ubuntu 24.04, duplicate FilesMatch block
- Self-referencing variable, yes/no booleans, unnecessary ignore_errors
- Staging TF drift/VPC documentation comments

## Test plan

- [ ] `terraform init -backend=false && terraform validate` in staging environment
- [ ] `ansible-playbook --syntax-check ansible/site.yml`
- [ ] `docker compose -f scripts/docker/docker-compose.yml config`
- [ ] Verify all workflow YAML is valid