### PR TITLE
fix(terraform): update DO Spaces backend for Terraform 1.10+ endpoint format

### DIFF
--- a/terraform/backend.hcl
+++ b/terraform/backend.hcl
@@ -1,9 +1,12 @@
 # Shared S3 backend configuration for DigitalOcean Spaces
 # Used by all environments via: terraform init -backend-config=../../backend.hcl
-endpoint                    = "sfo2.digitaloceanspaces.com"
-region                      = "us-west-1"
-bucket                      = "pausatf-terraform-state"
-skip_credentials_validation = true
-skip_metadata_api_check     = true
-skip_region_validation      = true
-use_lockfile                = true
+endpoints = {
+  s3 = "https://sfo2.digitaloceanspaces.com"
+}
+region                       = "us-west-1"
+bucket                       = "pausatf-terraform-state"
+skip_credentials_validation  = true
+skip_metadata_api_check      = true
+skip_region_validation       = true
+skip_requesting_account_id   = true
+use_lockfile                 = true


### PR DESCRIPTION
## Intent
Fix S3 backend config for DigitalOcean Spaces compatibility with Terraform 1.10+.

## Changes
- `endpoint` → `endpoints = { s3 = "..." }` (deprecated parameter, Terraform 1.10 warns)
- Add `skip_requesting_account_id = true` (DO Spaces has no STS/IAM — plan fails without this)

## Risk
Low — backend config only affects where state is stored, not what resources are managed. No state migration required; bucket and key are unchanged.

## Verification
```bash
AWS_ACCESS_KEY_ID=<spaces-key> AWS_SECRET_ACCESS_KEY=<spaces-secret> \
  terraform init -backend-config=terraform/backend.hcl \
  -backend-config="skip_requesting_account_id=true" \
  terraform/environments/dev
```