### PR TITLE
fix(cloud-init): set disable_root: true in base and OLS templates

### DIFF
--- a/terraform/modules/droplet/cloud-init-base.yml
+++ b/terraform/modules/droplet/cloud-init-base.yml
@@ -130,7 +130,7 @@ runcmd:
 
 # SSH configuration
 ssh_pwauth: false
-disable_root: false
+disable_root: true
 
 # Final message
 final_message: |

--- a/terraform/modules/droplet/cloud-init-openlitespeed.yml
+++ b/terraform/modules/droplet/cloud-init-openlitespeed.yml
@@ -342,7 +342,7 @@ runcmd:
 
 # SSH security
 ssh_pwauth: false
-disable_root: false
+disable_root: true
 
 # Final message
 final_message: |


### PR DESCRIPTION
## What

Set `disable_root: true` in `cloud-init-base.yml` and `cloud-init-openlitespeed.yml` (one line each).

## Why

`cloud-init-ubuntu-24.yml` (the production template) already has `disable_root: true`. The base and OLS templates were inconsistent — staging/dev droplets provisioned from them had root SSH login enabled at the cloud-init level, even though `ssh_pwauth: false` and the `PermitRootLogin prohibit-password` sed are also present.

Aligns all three templates. No functional impact on production (which uses the ubuntu-24 template).

## Verification

```
grep disable_root terraform/modules/droplet/cloud-init-*.yml
```

Expected: all three lines read `disable_root: true`.