### PR TITLE
feat(ansible): activate redis-cache plugin and drop-in via wp-cli

### DIFF
--- a/ansible/roles/wordpress/tasks/manage-install.yml
+++ b/ansible/roles/wordpress/tasks/manage-install.yml
@@ -87,6 +87,33 @@
     - web_server | default('apache') == 'openlitespeed'
     - lscache_installed.rc != 0
 
+- name: Check if redis-cache plugin is installed
+  command: "{{ wpcli_path | default('/usr/local/bin/wp') }} plugin is-installed redis-cache --path={{ wp_site.path }} --allow-root"
+  register: redis_cache_installed
+  changed_when: false
+  failed_when: false
+  when: redis_enabled | default(false)
+
+- name: Install redis-cache plugin
+  command: "{{ wpcli_path | default('/usr/local/bin/wp') }} plugin install redis-cache --path={{ wp_site.path }} --allow-root"
+  when:
+    - redis_enabled | default(false)
+    - redis_cache_installed.rc != 0
+
+- name: Activate redis-cache plugin
+  command: "{{ wpcli_path | default('/usr/local/bin/wp') }} plugin activate redis-cache --path={{ wp_site.path }} --allow-root"
+  register: redis_cache_activate
+  changed_when: "'activated' in redis_cache_activate.stdout | lower"
+  failed_when: false
+  when: redis_enabled | default(false)
+
+- name: Enable Redis object cache drop-in
+  command: "{{ wpcli_path | default('/usr/local/bin/wp') }} redis enable --path={{ wp_site.path }} --allow-root"
+  register: redis_enable_result
+  changed_when: "'enabled' in redis_enable_result.stdout | lower"
+  failed_when: false
+  when: redis_enabled | default(false)
+
 - name: Set WordPress file and directory permissions
   file:
     path: "{{ wp_site.path }}"


### PR DESCRIPTION
Install and activate the redis-cache plugin if not already present, then run \`wp redis enable\` to create the \`object-cache.php\` drop-in.

- Gated by \`redis_enabled\` (default false) — no-op on sites without Redis
- Completes the Redis object cache setup started in group_vars (plugin added in commit 83f1e1dd)
- All four tasks are idempotent: check before install, \`changed_when\` guards on activate and enable

**Verify:** Run the wordpress role against staging with \`redis_enabled: true\`; confirm \`object-cache.php\` appears in \`wp-content/\` and \`wp redis status\` reports enabled.