### PR TITLE
fix(terraform): remove stale ACME challenge TXT record

### DIFF
--- a/terraform/environments/cloudflare/main.tf
+++ b/terraform/environments/cloudflare/main.tf
@@ -378,19 +378,6 @@ resource "cloudflare_dns_record" "dkim_cloudflare" {
 }
 
 # =============================================================================
-# DNS Records — ACME Challenge
-# =============================================================================
-
-resource "cloudflare_dns_record" "acme_challenge_www" {
-  zone_id = cloudflare_zone.pausatf.id
-  name    = "_acme-challenge.www"
-  content = "JmQAJz96_x3ZwO5VqAfTMWAu5GMU7HXgGcaCpoRB2Cg" # pragma: allowlist secret
-  type    = "TXT"
-  ttl     = 1
-  comment = "Let's Encrypt ACME challenge (may be temporary)"
-}
-
-# =============================================================================
 # DNS Records — CAA
 # =============================================================================
 


### PR DESCRIPTION
## What changed

Removed `cloudflare_dns_record.acme_challenge_www` from `terraform/environments/cloudflare/main.tf`.

## Why

The certbot role uses `certbot-dns-cloudflare` (DNS-01) and creates/removes `_acme-challenge.*` records automatically during renewal. The static TXT record was created during the initial manual certificate issuance and has been stale since. Its own comment said "may be temporary".

## Risk

On next `terraform apply`, the record is deleted from Cloudflare DNS. That is the intended outcome — certbot manages these transiently during renewal. No impact to normal site operation.

## Verification

```
terraform plan -chdir=terraform/environments/cloudflare
# Expected: 1 to destroy (cloudflare_dns_record.acme_challenge_www)
```