### PR TITLE
fix(ci): remove path filters from required-check workflows

### DIFF
--- a/.github/workflows/ansible-lint.yml
+++ b/.github/workflows/ansible-lint.yml
@@ -2,12 +2,6 @@ name: Ansible Lint
 
 on:
   pull_request:
-    paths:
-      - 'ansible/**.yml'
-      - 'ansible/**.yaml'
-      - 'ansible/roles/**'
-      - 'ansible/playbooks/**'
-      - '.github/workflows/ansible-lint.yml'
   push:
     branches:
       - main

--- a/.github/workflows/markdown-lint.yml
+++ b/.github/workflows/markdown-lint.yml
@@ -2,11 +2,6 @@ name: Markdown Lint
 
 on:
   pull_request:
-    paths:
-      - '**.md'
-      - '.github/workflows/markdown-lint.yml'
-      - '.markdownlint.json'
-      - '.markdown-link-check.json'
   push:
     branches:
       - main

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -2,9 +2,6 @@ name: ShellCheck
 
 on:
   pull_request:
-    paths:
-      - 'scripts/**.sh'
-      - '.github/workflows/shellcheck.yml'
   push:
     branches:
       - main

--- a/.github/workflows/terraform-validate.yml
+++ b/.github/workflows/terraform-validate.yml
@@ -2,9 +2,6 @@ name: Terraform Validate
 
 on:
   pull_request:
-    paths:
-      - 'terraform/**.tf'
-      - '.github/workflows/terraform-validate.yml'
   push:
     branches:
       - main


### PR DESCRIPTION
Required checks (ansible-lint, terraform-validate, shellcheck, markdown-lint) have path filters on pull_request triggers — PRs that don't touch those paths never get the check and are blocked. Remove paths: from pull_request events; keep paths: on push to main to avoid unnecessary runs on merge commits.