### PR TITLE
fix(ci): ignore flaky/auth-required URLs in markdown-link-check

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -18,7 +18,11 @@
     { "pattern": "^https://elegantthemes\\.com" },
     { "pattern": "^https://www\\.isitdownrightnow\\.com" },
     { "pattern": "^https://docs\\.digitalocean\\.com/products/droplets/how-to/migrate" },
-    { "pattern": "^https://openlitespeed\\.org/kb" }
+    { "pattern": "^https://openlitespeed\\.org/kb" },
+    { "pattern": "^https://github\\.com/settings/" },
+    { "pattern": "^https://desktop\\.github\\.com" },
+    { "pattern": "^https://github\\.com/angular/angular" },
+    { "pattern": "^https://github\\.com/gdsmith/jquery\\.easing" }
   ],
   "timeout": "20s",
   "retryOn429": true,


### PR DESCRIPTION
Four URLs fail with status 0 / socket hang up in CI — not actual dead links:

- `github.com/settings/*` — auth-required, unreachable without login
- `desktop.github.com` — flaky in runner network
- `github.com/angular/angular` — flaky in runner network
- `github.com/gdsmith/jquery.easing` — flaky in runner network

Added targeted ignore patterns to `.markdown-link-check.json`.