### PR TITLE
feat(ansible): add managed DB migration playbook

### DIFF
--- a/ansible/playbooks/migrate-to-managed-db.yml
+++ b/ansible/playbooks/migrate-to-managed-db.yml
@@ -1,0 +1,443 @@
+---
+- name: Migrate WordPress database to DigitalOcean Managed MySQL
+  hosts: production
+  gather_facts: no
+  become: true
+
+  vars:
+    wp_path: "{{ wordpress_path | default('/var/www/html') }}"
+    wpcli: "{{ wpcli_path | default('/usr/local/bin/wp') }}"
+    migration_timestamp: "{{ lookup('pipe', 'date +%Y%m%dT%H%M%S') }}"
+    tmp_export: "/tmp/wordpress-export-{{ migration_timestamp }}.sql"
+    tmp_fullbackup: "/tmp/wordpress-db-premigration-{{ migration_timestamp }}.sql.gz"
+    tmp_mycnf: "/tmp/.managed-db-{{ migration_timestamp }}.cnf"
+    spaces_backup_prefix: "db-migration/{{ migration_timestamp }}"
+
+  pre_tasks:
+    # ========================================
+    # Phase 1: Pre-flight checks
+    # ========================================
+    - name: Validate production safety gate
+      fail:
+        msg: >-
+          This playbook migrates the production database to managed MySQL.
+          Pass --extra-vars "confirm_production=yes" to proceed.
+      when: confirm_production | default('no') != 'yes'
+
+    - name: Validate managed_db_host is defined
+      fail:
+        msg: "managed_db_host must be set in vault or group_vars (Terraform output: database_host)"
+      when: managed_db_host is not defined or managed_db_host | length == 0
+
+    - name: Validate managed_db_port is defined
+      fail:
+        msg: "managed_db_port must be set in group_vars (typically 25060 for DO managed MySQL)"
+      when: managed_db_port is not defined
+
+    - name: Validate managed_db_user is defined
+      fail:
+        msg: "managed_db_user must be set in vault or group_vars (Terraform output: database_user)"
+      when: managed_db_user is not defined or managed_db_user | length == 0
+
+    - name: Validate managed_db_password is defined
+      fail:
+        msg: "managed_db_password must be set in vault"
+      when: managed_db_password is not defined or managed_db_password | length == 0
+      no_log: true
+
+    - name: Fail if managed_db_host resolves to localhost
+      fail:
+        msg: "managed_db_host ({{ managed_db_host }}) must not be localhost"
+      when: managed_db_host in ['localhost', '127.0.0.1', '::1']
+
+    - name: Verify local MySQL is running
+      command: mysqladmin ping --host=localhost
+      changed_when: false
+
+    - name: Create temporary credentials file for managed DB
+      copy:
+        dest: "{{ tmp_mycnf }}"
+        mode: '0600'
+        content: |
+          [client]
+          host={{ managed_db_host }}
+          port={{ managed_db_port }}
+          user={{ managed_db_user }}
+          password={{ managed_db_password }}
+          ssl-mode=REQUIRED
+      no_log: true
+
+    - name: Verify managed MySQL is reachable
+      command: mysqladmin ping --defaults-extra-file={{ tmp_mycnf }}
+      changed_when: false
+      no_log: true
+
+    - name: Verify s3cmd is available
+      command: which s3cmd
+      changed_when: false
+      when: backup_enabled | default(true)
+
+    - name: Get WordPress database name
+      command: >-
+        {{ wpcli }} config get DB_NAME
+        --path={{ wp_path }} --allow-root
+      register: wp_db_name
+      changed_when: false
+
+    - name: Get WordPress database user
+      command: >-
+        {{ wpcli }} config get DB_USER
+        --path={{ wp_path }} --allow-root
+      register: wp_db_user
+      changed_when: false
+
+    - name: Get WordPress database host
+      command: >-
+        {{ wpcli }} config get DB_HOST
+        --path={{ wp_path }} --allow-root
+      register: wp_db_host
+      changed_when: false
+
+    - name: Get WordPress table prefix
+      command: >-
+        {{ wpcli }} config get table_prefix
+        --path={{ wp_path }} --allow-root
+      register: wp_table_prefix
+      changed_when: false
+
+    - name: Display migration plan
+      debug:
+        msg: |
+          === Migration Plan ===
+          Source: {{ wp_db_host.stdout | default('(check mode)') }}  (local MySQL)
+          Target: {{ managed_db_host }}:{{ managed_db_port }}  (DO Managed MySQL)
+          Database: {{ wp_db_name.stdout | default('(check mode)') }}
+          Timestamp: {{ migration_timestamp }}
+
+  tasks:
+    # ========================================
+    # Phase 2: Snapshot production droplet
+    # ========================================
+    - name: Validate DO_TOKEN is available
+      fail:
+        msg: "digitalocean_api_token must be set in vault for snapshot API calls"
+      when: digitalocean_api_token is not defined or digitalocean_api_token | length == 0
+      no_log: true
+
+    - name: Validate droplet ID is available
+      fail:
+        msg: "digitalocean_droplet_id must be set in group_vars"
+      when: digitalocean_droplet_id is not defined
+
+    - name: Create pre-migration droplet snapshot
+      uri:
+        url: "https://api.digitalocean.com/v2/droplets/{{ digitalocean_droplet_id }}/actions"
+        method: POST
+        headers:
+          Authorization: "Bearer {{ digitalocean_api_token }}"
+          Content-Type: "application/json"
+        body_format: json
+        body:
+          type: "snapshot"
+          name: "pre-db-migration-{{ migration_timestamp }}"
+        status_code: 201
+      register: snapshot_action
+      no_log: true
+
+    - name: Wait for snapshot to complete
+      uri:
+        url: "https://api.digitalocean.com/v2/actions/{{ snapshot_action.json.action.id }}"
+        method: GET
+        headers:
+          Authorization: "Bearer {{ digitalocean_api_token }}"
+        status_code: 200
+      register: snapshot_status
+      until: snapshot_status.json.action.status in ['completed', 'errored']
+      retries: 90
+      delay: 30
+      no_log: true
+      when: snapshot_action is not skipped
+
+    - name: Fail if snapshot errored
+      fail:
+        msg: "Snapshot action {{ snapshot_action.json.action.id }} ended with status: {{ snapshot_status.json.action.status }}"
+      when:
+        - snapshot_status is not skipped
+        - snapshot_status.json.action.status != 'completed'
+
+    - name: Display snapshot result
+      debug:
+        msg: "Snapshot 'pre-db-migration-{{ migration_timestamp }}' completed (action {{ snapshot_action.json.action.id }})"
+      when: snapshot_action is not skipped
+
+    # ========================================
+    # Phase 3: Full backup of local database
+    # ========================================
+    - name: Dump all local databases (full safety backup)
+      shell: >-
+        set -o pipefail &&
+        mysqldump --host=localhost
+        --single-transaction --routines --triggers
+        --all-databases | gzip > {{ tmp_fullbackup }}
+      args:
+        executable: /bin/bash
+      no_log: true
+
+    - name: Verify full backup file exists and is non-empty
+      stat:
+        path: "{{ tmp_fullbackup }}"
+      register: fullbackup_stat
+      failed_when: not fullbackup_stat.stat.exists or fullbackup_stat.stat.size == 0
+      when: not ansible_check_mode
+
+    - name: Upload full backup to Spaces
+      command: >-
+        s3cmd put {{ tmp_fullbackup }}
+        s3://pausatf-backups/{{ spaces_backup_prefix }}/wordpress-db-premigration.sql.gz
+      when:
+        - backup_enabled | default(true)
+        - not ansible_check_mode
+
+    # ========================================
+    # Phase 4: Export WordPress database
+    # ========================================
+    - name: Enable WordPress maintenance mode
+      command: >-
+        {{ wpcli }} maintenance-mode activate
+        --path={{ wp_path }} --allow-root
+
+    - name: Export WordPress database via WP-CLI
+      command: >-
+        {{ wpcli }} db export {{ tmp_export }}
+        --path={{ wp_path }} --allow-root
+      register: wp_export
+
+    - name: Verify export file line count
+      command: wc -l {{ tmp_export }}
+      register: export_linecount
+      changed_when: false
+      when: not ansible_check_mode
+
+    - name: Fail if export is suspiciously small
+      fail:
+        msg: "Export has only {{ export_linecount.stdout.split()[0] }} lines — expected a larger database"
+      when:
+        - not ansible_check_mode
+        - export_linecount.stdout.split()[0] | int < 100
+
+    - name: Display export stats
+      debug:
+        msg: "Exported {{ export_linecount.stdout.split()[0] }} lines to {{ tmp_export }}"
+      when: not ansible_check_mode
+
+    # ========================================
+    # Phase 5: Import to managed MySQL
+    # ========================================
+    - name: Get local row count before import
+      command: >-
+        {{ wpcli }} db query
+        "SELECT COUNT(*) FROM {{ (wp_table_prefix.stdout | default('wp_')) | trim }}posts"
+        --path={{ wp_path }} --allow-root --skip-column-names
+      register: local_post_count
+      changed_when: false
+
+    - name: Check if managed DB already has WordPress tables
+      command: >-
+        mysql --defaults-extra-file={{ tmp_mycnf }}
+        {{ wp_db_name.stdout | default('wordpress') }}
+        --skip-column-names
+        -e "SHOW TABLES LIKE '{{ (wp_table_prefix.stdout | default('wp_')) | trim }}%'"
+      register: managed_existing_tables
+      changed_when: false
+
+    - name: Fail if managed DB already has data
+      fail:
+        msg: >-
+          Managed DB already contains WordPress tables. This may indicate a
+          previous partial migration. Pass --extra-vars "force_reimport=yes"
+          to drop and reimport, or investigate manually.
+      when:
+        - not ansible_check_mode
+        - managed_existing_tables.stdout | default('') | length > 0
+        - force_reimport | default('no') != 'yes'
+
+    - name: Import WordPress database to managed MySQL
+      shell: >-
+        mysql --defaults-extra-file={{ tmp_mycnf }}
+        {{ wp_db_name.stdout | default('wordpress') }} < {{ tmp_export }}
+      no_log: true
+
+    # ========================================
+    # Phase 6: Verify managed DB data
+    # ========================================
+    - name: Get managed DB row count
+      command: >-
+        mysql --defaults-extra-file={{ tmp_mycnf }}
+        {{ wp_db_name.stdout | default('wordpress') }}
+        --skip-column-names
+        -e "SELECT COUNT(*) FROM {{ (wp_table_prefix.stdout | default('wp_')) | trim }}posts"
+      register: managed_post_count
+      changed_when: false
+
+    - name: Compare row counts
+      fail:
+        msg: >-
+          Row count mismatch — local: {{ local_post_count.stdout | trim }},
+          managed: {{ managed_post_count.stdout | trim }}
+      when:
+        - not ansible_check_mode
+        - local_post_count.stdout | default('') | trim != managed_post_count.stdout | default('') | trim
+
+    - name: Verify siteurl in managed DB
+      command: >-
+        mysql --defaults-extra-file={{ tmp_mycnf }}
+        {{ wp_db_name.stdout | default('wordpress') }}
+        --skip-column-names
+        -e "SELECT option_value FROM {{ (wp_table_prefix.stdout | default('wp_')) | trim }}options WHERE option_name = 'siteurl'"
+      register: managed_siteurl
+      changed_when: false
+
+    - name: Display data verification results
+      debug:
+        msg: |
+          === Data Verification ===
+          Posts rows (local):   {{ local_post_count.stdout | default('(check mode)') | trim }}
+          Posts rows (managed): {{ managed_post_count.stdout | default('(check mode)') | trim }}
+          siteurl (managed): {{ managed_siteurl.stdout | default('(check mode)') | trim }}
+      when: not ansible_check_mode
+
+    # ========================================
+    # Phase 7: Switch wp-config.php
+    # ========================================
+    - name: Check wp-config.php exists
+      stat:
+        path: "{{ wp_path }}/wp-config.php"
+      register: wpconfig_stat
+      when: not ansible_check_mode
+
+    - name: Backup current wp-config.php
+      copy:
+        src: "{{ wp_path }}/wp-config.php"
+        dest: "{{ wp_path }}/wp-config.php.local-mysql.bak"
+        remote_src: true
+        mode: '0640'
+        owner: "{{ apache_user | default('www-data') }}"
+        group: "{{ apache_group | default('www-data') }}"
+      when: not ansible_check_mode
+
+    - name: Update DB_HOST in wp-config.php
+      command: >-
+        {{ wpcli }} config set DB_HOST '{{ managed_db_host }}:{{ managed_db_port }}'
+        --path={{ wp_path }} --allow-root
+
+    - name: Update DB_USER in wp-config.php
+      command: >-
+        {{ wpcli }} config set DB_USER '{{ managed_db_user }}'
+        --path={{ wp_path }} --allow-root
+
+    - name: Update DB_PASSWORD in wp-config.php
+      command: >-
+        {{ wpcli }} config set DB_PASSWORD '{{ managed_db_password }}'
+        --path={{ wp_path }} --allow-root
+      no_log: true
+
+    - name: Add MYSQL_CLIENT_FLAGS for SSL
+      command: >-
+        {{ wpcli }} config set MYSQL_CLIENT_FLAGS MYSQLI_CLIENT_SSL
+        --path={{ wp_path }} --allow-root --raw --type=constant
+
+    - name: Reload PHP-FPM to pick up wp-config changes
+      service:
+        name: "php{{ php_version }}-fpm"
+        state: reloaded
+      when: not ansible_check_mode
+
+    # ========================================
+    # Phase 8: Verify WordPress on managed DB
+    # ========================================
+    - name: Verify WordPress is installed (managed DB)
+      command: >-
+        {{ wpcli }} core is-installed
+        --path={{ wp_path }} --allow-root
+
+    - name: Verify WordPress database integrity
+      command: >-
+        {{ wpcli }} db check
+        --path={{ wp_path }} --allow-root
+
+    - name: HTTP health check — WP REST API
+      uri:
+        url: "https://www.pausatf.org/wp-json/"
+        method: GET
+        status_code: 200
+        timeout: 30
+      register: rest_check
+      delegate_to: localhost
+      become: false
+
+    - name: HTTP health check — WP login page
+      uri:
+        url: "https://www.pausatf.org/wp-login.php"
+        method: GET
+        status_code: 200
+        timeout: 30
+      register: login_check
+      delegate_to: localhost
+      become: false
+
+    - name: Display health check results
+      debug:
+        msg: |
+          === Health Checks Passed ===
+          wp core is-installed: OK
+          wp db check: OK
+          /wp-json/ HTTP {{ rest_check.status | default('(check mode)') }}
+          /wp-login.php HTTP {{ login_check.status | default('(check mode)') }}
+      when: not ansible_check_mode
+
+    # ========================================
+    # Phase 9: Cleanup
+    # ========================================
+    - name: Disable WordPress maintenance mode
+      command: >-
+        {{ wpcli }} maintenance-mode deactivate
+        --path={{ wp_path }} --allow-root
+
+    - name: Remove temporary credentials file
+      file:
+        path: "{{ tmp_mycnf }}"
+        state: absent
+
+    - name: Remove local SQL export from /tmp
+      file:
+        path: "{{ tmp_export }}"
+        state: absent
+
+    - name: Remove full backup from /tmp
+      file:
+        path: "{{ tmp_fullbackup }}"
+        state: absent
+
+    - name: Display migration summary
+      debug:
+        msg: |
+          ============================================
+          Migration Complete
+          ============================================
+          Database migrated from local MySQL to:
+            {{ managed_db_host }}:{{ managed_db_port }}
+
+          Backup uploaded to:
+            s3://pausatf-backups/{{ spaces_backup_prefix }}/
+
+          Snapshot:
+            pre-db-migration-{{ migration_timestamp }}
+
+          Local MySQL is still running as fallback.
+          wp-config.php backup at:
+            {{ wp_path }}/wp-config.php.local-mysql.bak
+
+          === ROLLBACK (if needed) ===
+          cp {{ wp_path }}/wp-config.php.local-mysql.bak {{ wp_path }}/wp-config.php
+          systemctl reload php{{ php_version }}-fpm
+          ============================================


### PR DESCRIPTION
## Summary

- Adds `ansible/playbooks/migrate-to-managed-db.yml` — 9-phase playbook to migrate WordPress from local MySQL to DigitalOcean Managed MySQL
- Phases: pre-flight validation, droplet snapshot, full backup + Spaces upload, WP-CLI export under maintenance mode, idempotent import with existing-data guard, row-count verification, wp-config switch with PHP-FPM reload, HTTP health checks, cleanup
- Local MySQL left running as fallback; rollback is a single `cp` + service reload

## Prerequisites

Before running, add these to vault/group_vars (from `terraform output`):
- `managed_db_host`
- `managed_db_port` (25060)
- `managed_db_user`
- `managed_db_password`

## Test plan

- [x] `ansible-playbook --syntax-check` passes
- [x] `ansible-lint` passes
- [x] `checkov` passes
- [x] `yamllint` passes (line-length warnings only, consistent with repo)
- [x] Local `--check` dry run completes with `failed=0`
- [ ] Run against production with `--check --diff -e confirm_production=yes` (requires vault)
- [ ] Run actual migration against production