### PR TITLE
feat(terraform,ansible): add managed DB outputs and variables

### DIFF
--- a/ansible/group_vars/all.yml
+++ b/ansible/group_vars/all.yml
@@ -165,6 +165,13 @@ mysql_managed: false
 mysql_enabled: false
 mysql_port: 3306
 
+# DigitalOcean Managed MySQL (populated from Terraform outputs + vault)
+# To populate: terraform -chdir=terraform/environments/production output
+managed_db_host: "{{ vault_managed_db_host | default('') }}"
+managed_db_port: 25060
+managed_db_user: "{{ vault_managed_db_user | default('') }}"
+managed_db_password: "{{ vault_managed_db_password | default('') }}"
+
 # =============================================================================
 # WORDPRESS INSTALL DEFAULTS
 # =============================================================================

--- a/terraform/environments/production/outputs.tf
+++ b/terraform/environments/production/outputs.tf
@@ -40,6 +40,23 @@ output "database_uri" {
   sensitive   = true
 }
 
+output "database_user" {
+  description = "Production database admin username"
+  value       = module.wordpress.database_user
+  sensitive   = true
+}
+
+output "database_password" {
+  description = "Production database admin password"
+  value       = module.wordpress.database_password
+  sensitive   = true
+}
+
+output "database_name" {
+  description = "Production database default database name"
+  value       = module.wordpress.database_name
+}
+
 output "vpc_id" {
   description = "Production VPC ID"
   value       = module.wordpress.vpc_id

--- a/terraform/environments/staging/outputs.tf
+++ b/terraform/environments/staging/outputs.tf
@@ -35,6 +35,28 @@ output "database_uri" {
   sensitive   = true
 }
 
+output "database_port" {
+  description = "Staging database port"
+  value       = module.wordpress.database_port
+}
+
+output "database_user" {
+  description = "Staging database admin username"
+  value       = module.wordpress.database_user
+  sensitive   = true
+}
+
+output "database_password" {
+  description = "Staging database admin password"
+  value       = module.wordpress.database_password
+  sensitive   = true
+}
+
+output "database_name" {
+  description = "Staging database default database name"
+  value       = module.wordpress.database_name
+}
+
 output "firewall_id" {
   description = "Staging firewall ID"
   value       = module.wordpress.firewall_id

--- a/terraform/stacks/wordpress/outputs.tf
+++ b/terraform/stacks/wordpress/outputs.tf
@@ -51,6 +51,23 @@ output "database_urn" {
   value       = module.database.urn
 }
 
+output "database_user" {
+  description = "Managed database admin username"
+  value       = module.database.user
+  sensitive   = true
+}
+
+output "database_password" {
+  description = "Managed database admin password"
+  value       = module.database.password
+  sensitive   = true
+}
+
+output "database_name" {
+  description = "Managed database default database name"
+  value       = module.database.database
+}
+
 output "vpc_id" {
   description = "VPC ID"
   value       = var.create_vpc ? digitalocean_vpc.this[0].id : var.vpc_uuid_override


### PR DESCRIPTION
## Summary
- Add `database_user`, `database_password`, and `database_name` outputs to the wordpress Terraform stack and both production/staging environment configurations
- Add `managed_db_*` variables to Ansible `group_vars/all.yml` for the migration playbook (#104) to consume
- Update staging outputs to include `database_port` for consistency with production

## Context
PR #104 added the managed DB migration playbook. These outputs and variables wire the Terraform-provisioned database credentials through to Ansible so the migration can reference them.

## Test plan
- [x] `terraform validate` passes (all 3 directories)
- [x] `ansible-lint` passes
- [x] All pre-commit hooks pass (checkov, tflint, trivy, yamllint)