### PR TITLE
fix(terraform): align production config with existing infrastructure

### DIFF
--- a/ansible/.gitignore
+++ b/ansible/.gitignore
@@ -2,6 +2,7 @@
 *.retry
 *.log
 .vault_pass
+.vault_pass.sh
 .vault_password
 vault_pass.txt
 vault-password.txt

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -10,6 +10,7 @@ fact_caching_timeout = 3600
 stdout_callback = ansible.builtin.yaml
 bin_ansible_callbacks = True
 callbacks_enabled = profile_tasks, timer
+vault_password_file = .vault_pass.sh
 
 [inventory]
 enable_plugins = yaml, ini

--- a/terraform/environments/production/main.tf
+++ b/terraform/environments/production/main.tf
@@ -31,12 +31,19 @@ resource "digitalocean_project" "pausatf" {
   description = "Pacific Association of USA Track & Field"
   purpose     = "Website or blog"
   environment = "Production"
+  is_default  = true
 
   resources = [
     module.wordpress.droplet_urn,
     digitalocean_reserved_ip.production.urn,
     module.wordpress.database_urn,
   ]
+
+  lifecycle {
+    ignore_changes = [
+      resources,
+    ]
+  }
 }
 
 # SSH Key
@@ -49,16 +56,19 @@ resource "digitalocean_ssh_key" "m3_laptop" {
 module "wordpress" {
   source = "../../stacks/wordpress"
 
-  environment          = "production"
-  region               = var.region
-  droplet_size         = var.droplet_size
-  droplet_image        = var.droplet_image
-  database_size        = var.database_size
-  ssh_key_fingerprints = [digitalocean_ssh_key.m3_laptop.id]
-  vpc_cidr             = "10.10.0.0/16"
-  alert_emails         = var.alert_email_addresses
-  enable_backups       = true
-  enable_monitoring    = true
+  environment              = "production"
+  region                   = var.region
+  droplet_size             = "s-4vcpu-8gb"
+  droplet_image            = var.droplet_image
+  database_size            = var.database_size
+  ssh_key_fingerprints     = [digitalocean_ssh_key.m3_laptop.id]
+  alert_emails             = var.alert_email_addresses
+  enable_backups           = true
+  enable_monitoring        = false
+  enable_monitoring_alerts = false
+
+  create_vpc        = false
+  vpc_uuid_override = "4ee39499-dc85-11e8-9f23-3cfdfea9fff1"
 
   cloud_init_content = templatefile("${path.module}/../../modules/droplet/cloud-init-ubuntu-24.yml", {
     environment = "production"

--- a/terraform/environments/production/variables.tf
+++ b/terraform/environments/production/variables.tf
@@ -21,17 +21,6 @@ variable "region" {
   }
 }
 
-variable "droplet_size" {
-  description = "Droplet size slug"
-  type        = string
-  default     = "s-1vcpu-1gb"
-
-  validation {
-    condition     = startswith(var.droplet_size, "s-")
-    error_message = "Droplet size must start with 's-' (shared CPU)."
-  }
-}
-
 variable "droplet_image" {
   description = "Droplet base image"
   type        = string

--- a/terraform/modules/digitalocean/database/main.tf
+++ b/terraform/modules/digitalocean/database/main.tf
@@ -31,6 +31,10 @@ resource "digitalocean_database_cluster" "this" {
 
   lifecycle {
     prevent_destroy = true
+    ignore_changes = [
+      name,
+      private_network_uuid,
+    ]
   }
 }
 

--- a/terraform/stacks/wordpress/main.tf
+++ b/terraform/stacks/wordpress/main.tf
@@ -82,6 +82,10 @@ resource "digitalocean_droplet" "this" {
     create_before_destroy = true
     ignore_changes = [
       user_data,
+      image,
+      ssh_keys,
+      monitoring,
+      name,
     ]
   }
 }


### PR DESCRIPTION
## Summary
- Import existing DigitalOcean resources (droplet, DB, firewall, SSH key, project) into Terraform state
- Align configuration to prevent destructive replacements (VPC, droplet image/size, DB name)
- Create production managed MySQL cluster (`pausatf-prod-db`) and apply: reserved IP, DB firewall, wordpress DB/user, Cloudflare-only firewall rules
- Configure Ansible vault password file and gitignore

## Changes
- `terraform/environments/production/main.tf`: use existing VPC, hardcode droplet size, disable monitoring alerts, project lifecycle ignore
- `terraform/stacks/wordpress/main.tf`: add image/ssh_keys/monitoring/name to droplet ignore_changes
- `terraform/modules/digitalocean/database/main.tf`: add name/private_network_uuid to ignore_changes
- `ansible/ansible.cfg`: add vault_password_file
- `ansible/.gitignore`: add .vault_pass.sh

## Verification
- `terraform plan` shows "No changes. Your infrastructure matches the configuration."
- All pre-commit hooks pass (tflint, checkov, trivy, ansible-lint)

## Test plan
- [x] terraform validate passes
- [x] terraform plan shows no changes after apply
- [x] All pre-commit hooks pass