### PR TITLE
fix(ansible): harden migration and credential restore flows

### DIFF
--- a/ansible/playbooks/migrate-to-managed-db.yml
+++ b/ansible/playbooks/migrate-to-managed-db.yml
@@ -40,6 +40,15 @@
           Pass --extra-vars "confirm_production=yes" to proceed.
       when: confirm_production | default('no') != 'yes'
 
+    - name: Validate destructive reimport confirmation gate
+      fail:
+        msg: >-
+          force_reimport=yes is destructive and requires
+          --extra-vars "confirm_data_loss=yes" to proceed.
+      when:
+        - force_reimport | default('no') == 'yes'
+        - confirm_data_loss | default('no') != 'yes'
+
     - name: Validate managed_db_host is defined
       fail:
         msg: "managed_db_host must be set in vault or group_vars (Terraform output: database_host)"
@@ -296,6 +305,11 @@
           register: managed_existing_tables
           changed_when: false
 
+        - name: Normalize existing managed WordPress table list
+          set_fact:
+            managed_existing_table_list: "{{ managed_existing_tables.stdout_lines | map('trim') | reject('equalto', '') | list }}"
+          changed_when: false
+
         - name: Fail if managed DB already has data
           fail:
             msg: >-
@@ -304,8 +318,19 @@
               to drop and reimport, or investigate manually.
           when:
             - not ansible_check_mode
-            - managed_existing_tables.stdout | default('') | length > 0
+            - managed_existing_table_list | length > 0
             - force_reimport | default('no') != 'yes'
+
+        - name: Drop existing managed WordPress tables before forced reimport
+          command: >-
+            mysql --defaults-extra-file={{ tmp_mycnf }}
+            {{ wp_db_name.stdout | default('wordpress') }}
+            -e "SET FOREIGN_KEY_CHECKS=0; DROP TABLE IF EXISTS \`{{ item | replace('`', '``') }}\`; SET FOREIGN_KEY_CHECKS=1;"
+          loop: "{{ managed_existing_table_list | default([]) }}"
+          when:
+            - not ansible_check_mode
+            - managed_existing_table_list | length > 0
+            - force_reimport | default('no') == 'yes'
 
         - name: Import WordPress database to managed MySQL
           shell: >-

--- a/ansible/playbooks/reset-wp-admin-passwords.yml
+++ b/ansible/playbooks/reset-wp-admin-passwords.yml
@@ -48,9 +48,17 @@
       loop: "{{ wp_new_passwords | dict2items }}"
       no_log: true
 
-    - name: Display new credentials
-      debug:
-        msg: |
+    - name: Build secure credential file path
+      set_fact:
+        wp_password_output_file: "/root/wp-admin-password-reset-{{ lookup('pipe', 'date +%Y%m%dT%H%M%S') }}.txt"
+
+    - name: Write new credentials to root-only file
+      copy:
+        dest: "{{ wp_password_output_file }}"
+        owner: root
+        group: root
+        mode: '0600'
+        content: |
           ============================================
           WordPress Admin Password Reset Complete
           ============================================
@@ -59,6 +67,17 @@
           Pass: {{ password }}
           {% endfor %}
           ============================================
-          SAVE THESE PASSWORDS NOW — they won't be shown again.
+      no_log: true
+
+    - name: Display secure credential retrieval instructions
+      debug:
+        msg: |
           ============================================
-      no_log: false
+          WordPress Admin Password Reset Complete
+          ============================================
+          Credentials for {{ wp_admin_list | length }} administrator account(s)
+          were written to:
+            {{ wp_password_output_file }}
+          File permissions are 0600 (root only).
+          Retrieve securely and delete the file after distribution.
+          ============================================

--- a/ansible/playbooks/restore-prod.yml
+++ b/ansible/playbooks/restore-prod.yml
@@ -15,6 +15,7 @@
 
   vars:
     wp_path: /var/www/html
+    wpcli: "{{ wpcli_path | default('/usr/local/bin/wp') }}"
     legacy_path: /var/www/legacy
     temp_restore_dir: /tmp/pausatf-restore
 
@@ -95,35 +96,54 @@
       args:
         creates: "{{ temp_restore_dir }}/wordpress-db.sql"
 
-    - name: Get database credentials from wp-config
-      shell: grep {{ item.key }} {{ wp_path }}/wp-config.php | cut -d "'" -f 4
-      register: db_creds
-      loop:
-        - { key: 'DB_NAME', var: 'db_name' }
-        - { key: 'DB_USER', var: 'db_user' }
-        - { key: 'DB_PASSWORD', var: 'db_pass' }
-        - { key: 'DB_HOST', var: 'db_host' }
+    - name: Get database name from wp-config
+      command: >-
+        {{ wpcli }} config get DB_NAME
+        --path={{ wp_path }} --allow-root
+      register: wp_db_name
+      changed_when: false
+
+    - name: Get database user from wp-config
+      command: >-
+        {{ wpcli }} config get DB_USER
+        --path={{ wp_path }} --allow-root
+      register: wp_db_user
+      changed_when: false
+
+    - name: Get database password from wp-config
+      command: >-
+        {{ wpcli }} config get DB_PASSWORD
+        --path={{ wp_path }} --allow-root
+      register: wp_db_password
       changed_when: false
       no_log: true
 
+    - name: Validate wp-config database credentials are non-empty
+      assert:
+        that:
+          - wp_db_name.stdout | trim | length > 0
+          - wp_db_user.stdout | trim | length > 0
+          - wp_db_password.stdout | trim | length > 0
+        fail_msg: "Could not read DB_NAME/DB_USER/DB_PASSWORD from wp-config.php"
+
     - name: Create WordPress database
       mysql_db:
-        name: "{{ db_creds.results[0].stdout }}"
+        name: "{{ wp_db_name.stdout | trim }}"
         state: present
         login_user: root
 
     - name: Create WordPress database user
       mysql_user:
-        name: "{{ db_creds.results[1].stdout }}"
-        password: "{{ db_creds.results[2].stdout }}"
-        priv: "{{ db_creds.results[0].stdout }}.*:SELECT,INSERT,UPDATE,DELETE,CREATE,DROP,INDEX,ALTER,CREATE TEMPORARY TABLES"
+        name: "{{ wp_db_user.stdout | trim }}"
+        password: "{{ wp_db_password.stdout | trim }}"
+        priv: "{{ wp_db_name.stdout | trim }}.*:SELECT,INSERT,UPDATE,DELETE,CREATE,DROP,INDEX,ALTER,CREATE TEMPORARY TABLES"
         state: present
         login_user: root
       no_log: true
 
     - name: Import WordPress database
       mysql_db:
-        name: "{{ db_creds.results[0].stdout }}"
+        name: "{{ wp_db_name.stdout | trim }}"
         state: import
         target: "{{ temp_restore_dir }}/wordpress-db.sql"
         login_user: root


### PR DESCRIPTION
## Summary
- add destructive safety gate for forced managed DB reimport (confirm_data_loss=yes)
- make force reimport deterministic by normalizing existing table list and dropping matching tables before import
- replace brittle wp-config parsing in restore playbook with wp config get plus assertions
- stop printing admin reset passwords to logs; write credentials to a root-only file

## Validation
- pre-commit hooks on commit/cherry-pick (including ansible-lint and yamllint)
- ansible syntax checks for changed playbooks
- php lint for touched PHP file during remediation work
