### PR TITLE
fix(themes): remove duplicate header social icons

### DIFF
--- a/themes/thesource-child/header.php
+++ b/themes/thesource-child/header.php
@@ -172,39 +172,6 @@
 
 
 
-<!-- Start Social Icons -->
-<!-- Social icon styles enqueued via style.css -->
-<?php
-$social_links = [
-	'facebook'  => [
-		'url'   => get_theme_mod( 'pausatf_social_facebook',  'https://www.facebook.com/pausatf' ),
-		'label' => 'Facebook',
-		'svg'   => '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true"><path d="M22 12a10 10 0 1 0-11.563 9.873v-6.988H7.898V12h2.54V9.797c0-2.506 1.492-3.89 3.777-3.89 1.094 0 2.238.195 2.238.195v2.46h-1.26c-1.243 0-1.63.771-1.63 1.562V12h2.773l-.443 2.885h-2.33v6.988A10.003 10.003 0 0 0 22 12z"/></svg>',
-	],
-	'instagram' => [
-		'url'   => get_theme_mod( 'pausatf_social_instagram', 'https://www.instagram.com/usatfpacificassoc/' ),
-		'label' => 'Instagram',
-		'svg'   => '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true"><path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 1 0 0 12.324 6.162 6.162 0 0 0 0-12.324zM12 16a4 4 0 1 1 0-8 4 4 0 0 1 0 8zm6.406-11.845a1.44 1.44 0 1 0 0 2.881 1.44 1.44 0 0 0 0-2.881z"/></svg>',
-	],
-	'youtube'   => [
-		'url'   => get_theme_mod( 'pausatf_social_youtube', 'https://www.youtube.com/channel/UC4UDU5_ALy26O1vU6rAOjjA' ),
-		'label' => 'YouTube',
-		'svg'   => '<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" role="img" aria-hidden="true"><path d="M23.498 6.186a3.016 3.016 0 0 0-2.122-2.136C19.505 3.545 12 3.545 12 3.545s-7.505 0-9.377.505A3.017 3.017 0 0 0 .502 6.186C0 8.07 0 12 0 12s0 3.93.502 5.814a3.016 3.016 0 0 0 2.122 2.136c1.871.505 9.376.505 9.376.505s7.505 0 9.377-.505a3.015 3.015 0 0 0 2.122-2.136C24 15.93 24 12 24 12s0-3.93-.502-5.814zM9.545 15.568V8.432L15.818 12l-6.273 3.568z"/></svg>',
-	],
-];
-foreach ( array_reverse( $social_links ) as $network => $opts ) :
-	if ( empty( $opts['url'] ) ) continue;
-?>
-<div style="float:right; margin: 12px 10px 0 0;">
-	<a href="<?php echo esc_url( $opts['url'] ); ?>" class="social-icon-link social-icon-<?php echo esc_attr( $network ); ?>"
-	   target="_blank" rel="noopener noreferrer" aria-label="<?php echo esc_attr( $opts['label'] ); ?>">
-		<?php echo $opts['svg']; // phpcs:ignore WordPress.Security.EscapeOutput ?>
-	</a>
-</div>
-<?php endforeach; ?>
-<!-- End Social Icons -->
-
-
 				</div> <!-- end #cat-nav-content -->
 
 				<div id="cat-nav-right"> </div>


### PR DESCRIPTION
## Summary
- remove the extra hardcoded social icon block from `themes/thesource-child/header.php`
- keep the menu-based social icons so Facebook/Instagram only render once in header

## Why
Front page was rendering two icon sets in the header area; this removes the duplicate set below the menu bar on the right.

## Validation
- `php -l themes/thesource-child/header.php`
- pre-commit hooks passed during commit
