### PR TITLE
chore(gitignore): track Terraform lockfiles; ignore ansible/.vault_pass.sh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,6 @@ mysql-pass.txt
 *.tfplan
 *.tfplan.*
 .terraform/
-.terraform.lock.hcl
 **/.terraform/*
 .terraform.d/
 .terraform.tfstate.lock.info
@@ -75,6 +74,7 @@ roles/galaxy/
 .molecule/
 .cache/
 .pytest_cache/
+ansible/.vault_pass.sh
 
 # ============================================================================
 # Python


### PR DESCRIPTION
- Stop ignoring .terraform.lock.hcl to ensure reproducible provider selections across operators and CI.
- Add ansible/.vault_pass.sh to .gitignore to prevent accidental commits of a local vault helper.

No functional changes; follow-up PRs will add CI checks and lockfiles where applicable.

Co-Authored-By: Oz <oz-agent@warp.dev>